### PR TITLE
Bugfixes

### DIFF
--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -154,7 +154,7 @@ def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',
     # Create widgets
     axes_mode_wid = ipywidgets.RadioButtons(
         options={'Image': 1, 'Point cloud': 2}, description='Axes mode:',
-        value=2)
+        value=1)
     axes_mode_wid.on_trait_change(render_function, 'value')
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['markers', 'lines', 'numbering', 'zoom_one', 'axes'],
@@ -207,8 +207,8 @@ def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    axes_mode_wid.value = 1
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8),
@@ -419,8 +419,8 @@ def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8),
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[3].render_legend_checkbox.value = False
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
@@ -640,8 +640,8 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[3].render_legend_checkbox.value = False
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_images(images, figure_size=(10, 8), style='coloured',
@@ -865,8 +865,8 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[3].render_legend_checkbox.value = False
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_patches(patches, patch_centers, figure_size=(10, 8),
@@ -1021,7 +1021,7 @@ def visualize_patches(patches, patch_centers, figure_size=(10, 8),
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['markers', 'lines', 'numbering', 'zoom_one', 'axes',
                       'image'], labels=None,
-        axes_x_limits=0., axes_y_limits=None,
+        axes_x_limits=None, axes_y_limits=None,
         render_function=render_function,  style=renderer_style,
         tabs_style=renderer_tabs_style)
     info_wid = TextPrintWidget(n_lines=3, text_per_line=[''] * 3,
@@ -1083,9 +1083,8 @@ def visualize_patches(patches, patch_centers, figure_size=(10, 8),
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[4].axes_limits_widget.\
-        axes_x_limits_toggles.value = 'auto'
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def plot_graph(x_axis, y_axis, legend_entries=None, figure_size=(10, 6),
@@ -1196,8 +1195,8 @@ def plot_graph(x_axis, y_axis, legend_entries=None, figure_size=(10, 6),
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    wid.title.value = ' '
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def save_matplotlib_figure(renderer, style='coloured'):
@@ -1548,7 +1547,7 @@ def visualize_shape_model(shape_model, n_parameters=5, mode='multiple',
         style=model_parameters_style, continuous_update=False)
     axes_mode_wid = ipywidgets.RadioButtons(
         options={'Image': 1, 'Point cloud': 2}, description='Axes mode:',
-        value=2)
+        value=1)
     axes_mode_wid.on_trait_change(render_function, 'value')
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['markers', 'lines', 'numbering', 'zoom_one', 'axes'],
@@ -1610,8 +1609,8 @@ def visualize_shape_model(shape_model, n_parameters=5, mode='multiple',
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    axes_mode_wid.value = 1
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_appearance_model(appearance_model, n_parameters=5,
@@ -1817,7 +1816,7 @@ def visualize_appearance_model(appearance_model, n_parameters=5,
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['image', 'markers', 'lines', 'numbering', 'zoom_one',
                       'axes'], labels=first_label,
-        axes_x_limits=0., axes_y_limits=None,
+        axes_x_limits=None, axes_y_limits=None,
         render_function=render_function,  style=renderer_style,
         tabs_style=renderer_tabs_style)
     landmark_options_wid = LandmarkOptionsWidget(
@@ -1881,9 +1880,8 @@ def visualize_appearance_model(appearance_model, n_parameters=5,
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[5].axes_limits_widget. \
-        axes_x_limits_toggles.value = 'auto'
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_patch_appearance_model(appearance_model, centers,
@@ -2146,5 +2144,5 @@ def visualize_patch_appearance_model(appearance_model, centers,
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[0].interpolation_checkbox.value = True
+    # Trigger initial visualization
+    render_function('', True)

--- a/menpowidgets/menpofit/base.py
+++ b/menpowidgets/menpofit/base.py
@@ -15,7 +15,6 @@ import ipywidgets
 import IPython.display as ipydisplay
 
 import matplotlib.pyplot as plt
-from matplotlib import collections as mc
 
 from menpo.base import name_of_callable
 from menpo.image import MaskedImage
@@ -26,7 +25,7 @@ from ..options import (
     ChannelOptionsWidget, PatchOptionsWidget, LandmarkOptionsWidget,
     LinearModelParametersWidget, PlotOptionsWidget, AnimationOptionsWidget,
     TextPrintWidget)
-from ..style import map_styles_to_hex_colours, format_box
+from ..style import map_styles_to_hex_colours
 from ..tools import LogoWidget
 from ..utils import (
     render_patches, render_image, extract_groups_labels_from_image,
@@ -300,7 +299,7 @@ def visualize_aam(aam, n_shape_parameters=5, n_appearance_parameters=5,
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['markers', 'lines', 'image', 'numbering', 'zoom_one',
                       'axes'], labels=labels_keys[0],
-        axes_x_limits=0., axes_y_limits=None,
+        axes_x_limits=None, axes_y_limits=None,
         render_function=render_function,  style=renderer_style,
         tabs_style=renderer_tabs_style)
     landmark_options_wid = LandmarkOptionsWidget(
@@ -378,9 +377,8 @@ def visualize_aam(aam, n_shape_parameters=5, n_appearance_parameters=5,
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[5].axes_limits_widget. \
-        axes_x_limits_toggles.value = 'auto'
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_patch_aam(aam, n_shape_parameters=5, n_appearance_parameters=5,
@@ -710,8 +708,8 @@ def visualize_patch_aam(aam, n_shape_parameters=5, n_appearance_parameters=5,
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[0].interpolation_checkbox.value = True
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_atm(atm, n_shape_parameters=5, mode='multiple',
@@ -926,7 +924,7 @@ def visualize_atm(atm, n_shape_parameters=5, mode='multiple',
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['markers', 'lines', 'image', 'numbering', 'zoom_one',
                       'axes'], labels=labels_keys[0],
-        axes_x_limits=0., axes_y_limits=None,
+        axes_x_limits=None, axes_y_limits=None,
         render_function=render_function,  style=renderer_style,
         tabs_style=renderer_tabs_style)
     landmark_options_wid = LandmarkOptionsWidget(
@@ -991,9 +989,8 @@ def visualize_atm(atm, n_shape_parameters=5, mode='multiple',
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[5].axes_limits_widget. \
-        axes_x_limits_toggles.value = 'auto'
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def visualize_patch_atm(atm, n_shape_parameters=5, mode='multiple',
@@ -1257,8 +1254,8 @@ def visualize_patch_atm(atm, n_shape_parameters=5, mode='multiple',
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    renderer_options_wid.options_widgets[0].interpolation_checkbox.value = True
+    # Trigger initial visualization
+    render_function('', True)
 
 
 def plot_ced(errors, legend_entries=None, error_range=None,
@@ -1389,6 +1386,7 @@ def plot_ced(errors, legend_entries=None, error_range=None,
         list(np.arange(0., 1.1, 0.1)), allow_callback=False)
     wid.x_label.value = x_label
     wid.y_label.value = 'Images Proportion'
+    wid.title.value = 'Cumulative error distribution'
     wid.add_render_function(render_function)
 
     # Group widgets
@@ -1410,8 +1408,8 @@ def plot_ced(errors, legend_entries=None, error_range=None,
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
-    wid.title.value = 'Cumulative error distribution'
+    # Trigger initial visualization
+    render_function('', True)
 
     # return widget object if asked
     if return_widget:
@@ -1840,5 +1838,5 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
     # Display final widget
     ipydisplay.display(wid)
 
-    # Reset value to trigger initial visualization
+    # Set render legend to True to trigger initial visualization
     renderer_options_wid.options_widgets[2].render_legend_checkbox.value = True

--- a/menpowidgets/menpofit/options.py
+++ b/menpowidgets/menpofit/options.py
@@ -127,10 +127,8 @@ class FittingResultOptionsWidget(MenpoWidget):
         self.shape_selection = [
             ipywidgets.Latex(value='Shape:', margin='0.2cm'),
             ipywidgets.ToggleButton(description='Initial', value=False),
-            ipywidgets.ToggleButton(description='Final', value=True)]
-        if has_groundtruth:
-            self.shape_selection.append(ipywidgets.ToggleButton(
-                description='Groundtruth', value=False))
+            ipywidgets.ToggleButton(description='Final', value=True),
+            ipywidgets.ToggleButton(description='Groundtruth', value=False)]
         self.result_box = ipywidgets.HBox(children=self.shape_selection,
                                           align='center', margin='0.2cm',
                                           padding='0.2cm')

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -2031,11 +2031,8 @@ class RendererOptionsWidget(MenpoWidget):
                     'axes_y_limits': axes_y_limits,
                     'axes_x_ticks': None, 'axes_y_ticks': None}
             elif o == 'legend':
-                rl = True
-                if labels is None:
-                    rl = False
                 self.global_options[o] = {
-                    'render_legend': rl, 'legend_title': '',
+                    'render_legend': False, 'legend_title': '',
                     'legend_font_name': 'sans-serif',
                     'legend_font_style': 'normal', 'legend_font_size': 10,
                     'legend_font_weight': 'normal',


### PR DESCRIPTION
This PR fixes two bugs spotted by @patricksnape :

1) The `visualize_images` widget would not trigger the initial visualization in case the input image had no landmarks.
2) The `visualize_fitting_result` widget would not show the fitted shape and its respective button in case the image of the provided fitting result didn't have any groundtruth landmarks (`gt_shape`).

Please do confirm that this PR fixes the above issues!
