### PR TITLE
Fix new observe bugs from IPywidgets 4.1

### DIFF
--- a/menpowidgets/abstract.py
+++ b/menpowidgets/abstract.py
@@ -57,16 +57,16 @@ class MenpoWidget(ipywidgets.FlexBox):
         """
         self._render_function = render_function
         if self._render_function is not None:
-            self.on_trait_change(self._render_function, 'selected_values')
+            self.observe(self._render_function, names='selected_values')
 
     def remove_render_function(self):
         r"""
         Method that removes the current `self._render_function()` from the
         widget and sets ``self._render_function = None``.
         """
-        self.on_trait_change(self._render_function, 'selected_values',
-                             remove=True)
-        self._render_function = None
+        if self._render_function is not None:
+            self.unobserve(self._render_function, names='selected_values')
+            self._render_function = None
 
     def replace_render_function(self, render_function):
         r"""

--- a/menpowidgets/abstract.py
+++ b/menpowidgets/abstract.py
@@ -49,7 +49,7 @@ class MenpoWidget(ipywidgets.FlexBox):
         Method that adds a `render_function()` to the widget. The signature of
         the given function is also stored in `self._render_function`.
 
-        Parameters
+        Parameters#
         ----------
         render_function : `function` or ``None``, optional
             The render function that behaves as a callback of the

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -1,12 +1,10 @@
 from collections import Sized, OrderedDict
 import matplotlib.pyplot as plt
 from matplotlib import collections as mc
-import numpy as np
 
 import ipywidgets
 import IPython.display as ipydisplay
 
-from menpo.base import name_of_callable
 from menpo.image import MaskedImage, Image
 from menpo.image.base import _convert_patches_list_to_single_array
 
@@ -19,8 +17,7 @@ from .style import format_box, map_styles_to_hex_colours
 from .tools import LogoWidget
 from .utils import (extract_group_labels_from_landmarks,
                     extract_groups_labels_from_image, render_image,
-                    render_patches, render_images,
-                    sample_colours_from_colourmap)
+                    render_patches)
 from .checks import check_n_parameters
 
 
@@ -155,7 +152,7 @@ def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',
     axes_mode_wid = ipywidgets.RadioButtons(
         options={'Image': 1, 'Point cloud': 2}, description='Axes mode:',
         value=1)
-    axes_mode_wid.on_trait_change(render_function, 'value')
+    axes_mode_wid.observe(render_function, names='value')
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['markers', 'lines', 'numbering', 'zoom_one', 'axes'],
         labels=None, axes_x_limits=0.1, axes_y_limits=0.1,
@@ -351,7 +348,7 @@ def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8),
     axes_mode_wid = ipywidgets.RadioButtons(
         options={'Image': 1, 'Point cloud': 2}, description='Axes mode:',
         value=1)
-    axes_mode_wid.on_trait_change(render_function, 'value')
+    axes_mode_wid.observe(render_function, names='value')
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['lines', 'markers', 'numbering', 'legend', 'zoom_one',
                       'axes'], labels=landmarkgroups[0].labels,
@@ -568,7 +565,7 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
     axes_mode_wid = ipywidgets.RadioButtons(
         options={'Image': 1, 'Point cloud': 2}, description='Axes mode:',
         value=1)
-    axes_mode_wid.on_trait_change(render_function, 'value')
+    axes_mode_wid.observe(render_function, names='value')
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['markers', 'lines', 'numbering', 'legend', 'zoom_one',
                       'axes'], labels=first_label,
@@ -1527,10 +1524,10 @@ def visualize_shape_model(shape_model, n_parameters=5, mode='multiple',
     mode_dict['Vectors'] = 2
     mode_wid = ipywidgets.RadioButtons(options=mode_dict,
                                        description='Mode:', value=1)
-    mode_wid.on_trait_change(render_function, 'value')
+    mode_wid.observe(render_function, names='value')
     mean_wid = ipywidgets.Checkbox(value=False,
                                    description='Render mean shape')
-    mean_wid.on_trait_change(render_function, 'value')
+    mean_wid.observe(render_function, names='value')
 
     # Function that controls mean shape checkbox visibility
     def mean_visible(name, value):
@@ -1539,7 +1536,7 @@ def visualize_shape_model(shape_model, n_parameters=5, mode='multiple',
         else:
             mean_wid.disabled = True
             mean_wid.value = False
-    mode_wid.on_trait_change(mean_visible, 'value')
+    mode_wid.observe(mean_visible, names='value')
     model_parameters_wid = LinearModelParametersWidget(
         n_parameters[0], render_function, params_str='param ',
         mode=mode, params_bounds=parameters_bounds, params_step=0.1,
@@ -1548,7 +1545,7 @@ def visualize_shape_model(shape_model, n_parameters=5, mode='multiple',
     axes_mode_wid = ipywidgets.RadioButtons(
         options={'Image': 1, 'Point cloud': 2}, description='Axes mode:',
         value=1)
-    axes_mode_wid.on_trait_change(render_function, 'value')
+    axes_mode_wid.observe(render_function, names='value')
     renderer_options_wid = RendererOptionsWidget(
         options_tabs=['markers', 'lines', 'numbering', 'zoom_one', 'axes'],
         labels=None, axes_x_limits=0.1, axes_y_limits=0.1,
@@ -1580,8 +1577,8 @@ def visualize_shape_model(shape_model, n_parameters=5, mode='multiple',
                 radio_str["Level {}".format(l)] = l
         level_wid = ipywidgets.RadioButtons(
             options=radio_str, description='Pyramid:', value=n_levels-1)
-        level_wid.on_trait_change(update_widgets, 'value')
-        level_wid.on_trait_change(render_function, 'value')
+        level_wid.observe(update_widgets, names='value')
+        level_wid.observe(render_function, names='value')
         radio_children = [level_wid, mode_wid, mean_wid]
     else:
         radio_children = [mode_wid, mean_wid]
@@ -1854,8 +1851,8 @@ def visualize_appearance_model(appearance_model, n_parameters=5,
                 radio_str["Level {}".format(l)] = l
         level_wid = ipywidgets.RadioButtons(
             options=radio_str, description='Pyramid:', value=n_levels-1)
-        level_wid.on_trait_change(update_widgets, 'value')
-        level_wid.on_trait_change(render_function, 'value')
+        level_wid.observe(update_widgets, names='value')
+        level_wid.observe(render_function, names='value')
         tmp_children.insert(0, level_wid)
     tmp_wid = ipywidgets.HBox(children=tmp_children)
     options_box = ipywidgets.Tab(children=[tmp_wid, channel_options_wid,
@@ -2119,8 +2116,8 @@ def visualize_patch_appearance_model(appearance_model, centers,
                 radio_str["Level {}".format(l)] = l
         level_wid = ipywidgets.RadioButtons(
             options=radio_str, description='Pyramid:', value=n_levels-1)
-        level_wid.on_trait_change(update_widgets, 'value')
-        level_wid.on_trait_change(render_function, 'value')
+        level_wid.observe(update_widgets, names='value')
+        level_wid.observe(render_function, names='value')
         tmp_children.insert(0, level_wid)
     tmp_wid = ipywidgets.HBox(children=tmp_children)
     options_box = ipywidgets.Tab(children=[tmp_wid, patch_options_wid,

--- a/menpowidgets/menpofit/base.py
+++ b/menpowidgets/menpofit/base.py
@@ -350,8 +350,8 @@ def visualize_aam(aam, n_shape_parameters=5, n_appearance_parameters=5,
                 radio_str["Level {}".format(l)] = l
         level_wid = ipywidgets.RadioButtons(
             options=radio_str, description='Pyramid:', value=n_levels-1)
-        level_wid.on_trait_change(update_widgets, 'value')
-        level_wid.on_trait_change(render_function, 'value')
+        level_wid.observe(update_widgets, 'value')
+        level_wid.observe(render_function, names='value')
         tmp_children.insert(0, level_wid)
     tmp_wid = ipywidgets.HBox(children=tmp_children, align='center',
                               box_style=model_style)
@@ -682,8 +682,8 @@ def visualize_patch_aam(aam, n_shape_parameters=5, n_appearance_parameters=5,
                 radio_str["Level {}".format(l)] = l
         level_wid = ipywidgets.RadioButtons(
             options=radio_str, description='Pyramid:', value=n_levels-1)
-        level_wid.on_trait_change(update_widgets, 'value')
-        level_wid.on_trait_change(render_function, 'value')
+        level_wid.observe(update_widgets, names='value')
+        level_wid.observe(render_function, names='value')
         tmp_children.insert(0, level_wid)
     tmp_wid = ipywidgets.HBox(children=tmp_children, align='center',
                               box_style=model_style)
@@ -962,8 +962,8 @@ def visualize_atm(atm, n_shape_parameters=5, mode='multiple',
                 radio_str["Level {}".format(l)] = l
         level_wid = ipywidgets.RadioButtons(
             options=radio_str, description='Pyramid:', value=n_levels-1)
-        level_wid.on_trait_change(update_widgets, 'value')
-        level_wid.on_trait_change(render_function, 'value')
+        level_wid.observe(update_widgets, names='value')
+        level_wid.observe(render_function, names='value')
         tmp_children.insert(0, level_wid)
     tmp_wid = ipywidgets.HBox(children=tmp_children, align='center',
                               box_style=model_style)
@@ -1228,8 +1228,8 @@ def visualize_patch_atm(atm, n_shape_parameters=5, mode='multiple',
                 radio_str["Level {}".format(l)] = l
         level_wid = ipywidgets.RadioButtons(
             options=radio_str, description='Pyramid:', value=n_levels-1)
-        level_wid.on_trait_change(update_widgets, 'value')
-        level_wid.on_trait_change(render_function, 'value')
+        level_wid.observe(update_widgets, names='value')
+        level_wid.observe(render_function, names='value')
         tmp_children.insert(0, level_wid)
     tmp_wid = ipywidgets.HBox(children=tmp_children, align='center',
                               box_style=model_style)
@@ -1717,7 +1717,7 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
     error_type_values['RMS Error'] = 'rmse'
     error_type_wid = ipywidgets.RadioButtons(
         options=error_type_values, value='me_norm', description='Error type')
-    error_type_wid.on_trait_change(update_info, 'value')
+    error_type_wid.observe(update_info, names='value')
     plot_ced_but = ipywidgets.Button(description='Plot CED', visible=show_ced,
                                      button_style=plot_ced_but_style)
     error_wid = ipywidgets.VBox(children=[error_type_wid, plot_ced_but],
@@ -1751,13 +1751,13 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
             if value != 3:
                 plot_ced_widget.close()
                 plot_ced_but.visible = True
-        options_box.on_trait_change(close_plot_ced_fun, 'selected_index')
+        options_box.observe(close_plot_ced_fun, 'selected_index')
 
         # If another error type, then close the widget
         def close_plot_ced_fun_2(name, value):
             plot_ced_widget.close()
             plot_ced_but.visible = True
-        error_type_wid.on_trait_change(close_plot_ced_fun_2, 'value')
+        error_type_wid.observe(close_plot_ced_fun_2, names='value')
     plot_ced_but.on_click(plot_ced_fun)
 
     # Group widgets
@@ -1827,7 +1827,7 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
         def save_fig_tab_fun(name, value):
             if value == 3 and image_number_wid.play_options_toggle.value:
                 image_number_wid.stop_options_toggle.value = True
-        options_box.on_trait_change(save_fig_tab_fun, 'selected_index')
+        options_box.observe(save_fig_tab_fun, 'selected_index')
 
     # Set widget's style
     wid.box_style = widget_box_style

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -1109,22 +1109,23 @@ class LandmarkOptionsWidget(MenpoWidget):
             orientation='horizontal', align='start')
 
         # Set values
+        # Ensure that callbacks are added before being removed!
+        self.add_callbacks()
         self.set_widget_state(group_keys, labels_keys, allow_callback=False)
 
         # Set style
         self.predefined_style(style)
 
     def add_callbacks(self):
-        self.render_landmarks_checkbox.on_trait_change(
-            self._render_landmarks_fun, 'value')
-        self.group_dropdown.on_trait_change(self._group_fun, 'value')
+        self.render_landmarks_checkbox.observe(
+            self._render_landmarks_fun, names='value')
+        self.group_dropdown.observe(self._group_fun, names='value')
         self._add_function_to_labels_toggles(self._labels_fun)
 
     def remove_callbacks(self):
-        self.render_landmarks_checkbox.on_trait_change(
-            self._render_landmarks_fun, 'value', remove=True)
-        self.group_dropdown.on_trait_change(self._group_fun, 'value',
-                                            remove=True)
+        self.render_landmarks_checkbox.unobserve(
+            self._render_landmarks_fun, names='value')
+        self.group_dropdown.unobserve(self._group_fun, names='value')
         self._remove_function_from_labels_toggles(self._labels_fun)
 
     def _save_options(self, name, value):

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -205,12 +205,12 @@ class AnimationOptionsWidget(MenpoWidget):
                 # Change the description to Play
                 self.play_stop_toggle.icon = 'fa-play'
             self.play_options_toggle.disabled = value
-        self.play_stop_toggle.on_trait_change(play_stop_pressed, 'value')
+        self.play_stop_toggle.observe(play_stop_pressed, names='value')
 
         def play_options_visibility(name, value):
             self.loop_interval_box.visible = value
-        self.play_options_toggle.on_trait_change(play_options_visibility,
-                                                 'value')
+        self.play_options_toggle.observe(play_options_visibility,
+                                         names='value')
 
         def animate(name, value):
             if self.loop_checkbox.value:
@@ -264,11 +264,11 @@ class AnimationOptionsWidget(MenpoWidget):
                     sleep(self.interval_text.value)
                 if i > self.max:
                     self.play_stop_toggle.value = False
-        self.play_stop_toggle.on_trait_change(animate, 'value')
+        self.play_stop_toggle.observe(animate, names='value')
 
         def save_value(name, value):
             self.selected_values = self.index_wid.selected_values
-        self.index_wid.on_trait_change(save_value, 'selected_values')
+        self.index_wid.observe(save_value, names='selected_values')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -608,28 +608,26 @@ class ChannelOptionsWidget(MenpoWidget):
         self.predefined_style(style)
 
     def add_callbacks(self):
-        self.glyph_block_size_text.on_trait_change(self._save_options, 'value')
-        self.glyph_use_negative_checkbox.on_trait_change(self._save_options,
-                                                         'value')
-        self.masked_checkbox.on_trait_change(self._save_options, 'value')
-        self.channels_wid.on_trait_change(self._save_channels, 'selected_values')
-        self.rgb_checkbox.on_trait_change(self._save_rgb, 'value')
-        self.sum_checkbox.on_trait_change(self._save_sum, 'value')
-        self.glyph_checkbox.on_trait_change(self._save_glyph, 'value')
+        self.glyph_block_size_text.observe(self._save_options, names='value')
+        self.glyph_use_negative_checkbox.observe(self._save_options,
+                                                 names='value')
+        self.masked_checkbox.observe(self._save_options, names='value')
+        self.channels_wid.observe(self._save_channels, names='selected_values')
+        self.rgb_checkbox.observe(self._save_rgb, names='value')
+        self.sum_checkbox.observe(self._save_sum, names='value')
+        self.glyph_checkbox.observe(self._save_glyph, names='value')
 
     def remove_callbacks(self):
-        self.glyph_block_size_text.on_trait_change(self._save_options,
-                                                   'value', remove=True)
-        self.glyph_use_negative_checkbox.on_trait_change(self._save_options,
-                                                         'value', remove=True)
-        self.masked_checkbox.on_trait_change(self._save_options, 'value',
-                                             remove=True)
-        self.channels_wid.on_trait_change(self._save_channels, 'selected_values',
-                                          remove=True)
-        self.rgb_checkbox.on_trait_change(self._save_rgb, 'value', remove=True)
-        self.sum_checkbox.on_trait_change(self._save_sum, 'value', remove=True)
-        self.glyph_checkbox.on_trait_change(self._save_glyph, 'value',
-                                            remove=True)
+        self.glyph_block_size_text.unobserve(self._save_options,
+                                             names='value')
+        self.glyph_use_negative_checkbox.unobserve(self._save_options,
+                                                   names='value')
+        self.masked_checkbox.unobserve(self._save_options, names='value')
+        self.channels_wid.unobserve(self._save_channels,
+                                    names='selected_values')
+        self.rgb_checkbox.unobserve(self._save_rgb, names='value')
+        self.sum_checkbox.unobserve(self._save_sum, names='value')
+        self.glyph_checkbox.unobserve(self._save_glyph, names='value')
 
     def _save_options(self, name, value):
         # get channels value
@@ -651,53 +649,50 @@ class ChannelOptionsWidget(MenpoWidget):
     def _save_channels(self, name, value):
         if self.n_channels == 3:
             # temporarily remove rgb callback
-            self.rgb_checkbox.on_trait_change(self._save_rgb, 'value',
-                                              remove=True)
+            self.rgb_checkbox.unobserve(self._save_rgb, names='value')
             # set value
             self.rgb_checkbox.value = False
             # re-assign rgb callback
-            self.rgb_checkbox.on_trait_change(self._save_rgb, 'value')
+            self.rgb_checkbox.observe(self._save_rgb, names='value')
         self._save_options('', None)
 
     def _save_rgb(self, name, value):
         if value:
             # temporarily remove channels callback
-            self.channels_wid.on_trait_change(
-                self._save_channels, 'selected_values', remove=True)
+            self.channels_wid.unobserve(
+                self._save_channels, names='selected_values')
             # update channels widget
             self.channels_wid.set_widget_state(
                 {'command': '0, 1, 2', 'length': self.n_channels},
                 allow_callback=False)
             # re-assign channels callback
-            self.channels_wid.on_trait_change(self._save_channels,
-                                              'selected_values')
+            self.channels_wid.observe(self._save_channels,
+                                      names='selected_values')
         self._save_options('', None)
 
     def _save_sum(self, name, value):
         if value and self.glyph_checkbox.value:
             # temporarily remove glyph callback
-            self.glyph_checkbox.on_trait_change(self._save_glyph, 'value',
-                                                remove=True)
+            self.glyph_checkbox.unobserve(self._save_glyph, names='value')
 
             # set glyph to False
             self.glyph_checkbox.value = False
             self.glyph_options_box.visible = False
 
             # re-assign glyph callback
-            self.glyph_checkbox.on_trait_change(self._save_glyph, 'value')
+            self.glyph_checkbox.observe(self._save_glyph, names='value')
         self._save_options('', None)
 
     def _save_glyph(self, name, value):
         if value and self.sum_checkbox.value:
             # temporarily remove sum callback
-            self.sum_checkbox.on_trait_change(self._save_sum, 'value',
-                                              remove=True)
+            self.sum_checkbox.unobserve(self._save_sum, names='value')
 
             # set glyph to false
             self.sum_checkbox.value = False
 
             # re-assign sum callback
-            self.sum_checkbox.on_trait_change(self._save_sum, 'value')
+            self.sum_checkbox.observe(self._save_sum, names='value')
         # set visibility
         self.glyph_options_box.visible = value
         self._save_options('', None)
@@ -1149,11 +1144,11 @@ class LandmarkOptionsWidget(MenpoWidget):
             if len(self._get_with_labels()) == 0:
                 for ww in self.labels_box.children:
                     # temporarily remove render function
-                    ww.on_trait_change(self._labels_fun, 'value', remove=True)
+                    ww.unobserve(self._labels_fun, names='value')
                     # set value
                     ww.value = True
                     # re-add render function
-                    ww.on_trait_change(self._labels_fun, 'value')
+                    ww.observe(self._labels_fun, names='value')
         # set visibility
         self.options_box.visible = value
         # save options
@@ -1174,15 +1169,15 @@ class LandmarkOptionsWidget(MenpoWidget):
         # False
         if len(self._get_with_labels()) == 0:
             # temporarily remove render function
-            self.render_landmarks_checkbox.on_trait_change(
-                self._render_landmarks_fun, 'value', remove=True)
+            self.render_landmarks_checkbox.unobserve(
+                self._render_landmarks_fun, names='value')
             # set value
             self.render_landmarks_checkbox.value = False
             # set visibility
             self.options_box.visible = False
             # re-add render function
-            self.render_landmarks_checkbox.on_trait_change(
-                self._render_landmarks_fun, 'value')
+            self.render_landmarks_checkbox.observe(
+                self._render_landmarks_fun, names='value')
         # save options
         self._save_options('', None)
 
@@ -1225,12 +1220,12 @@ class LandmarkOptionsWidget(MenpoWidget):
     def _add_function_to_labels_toggles(self, fun):
         for s_group in self.labels_toggles:
             for w in s_group:
-                w.on_trait_change(fun, 'value')
+                w.observe(fun, names='value')
 
     def _remove_function_from_labels_toggles(self, fun):
         for s_group in self.labels_toggles:
             for w in s_group:
-                w.on_trait_change(fun, 'value', remove=True)
+                w.unobserve(fun, names='value')
 
     def _set_labels_toggles_values(self, with_labels):
         for w in self.labels_box.children:
@@ -1993,12 +1988,11 @@ class RendererOptionsWidget(MenpoWidget):
 
     def add_callbacks(self):
         for wid in self.options_widgets:
-            wid.on_trait_change(self._save_options, 'selected_values')
+            wid.observe(self._save_options, names='selected_values')
 
     def remove_callbacks(self):
         for wid in self.options_widgets:
-            wid.on_trait_change(self._save_options, 'selected_values',
-                                remove=True)
+            wid.observe(self._save_options, names='selected_values')
 
     def get_key(self, labels):
         return "{}".format(labels)
@@ -2564,12 +2558,12 @@ class SaveFigureOptionsWidget(ipywidgets.FlexBox):
         # Set functionality
         def papertype_visibility(name, value):
             self.papertype_select.visible = value == 'ps'
-        self.file_format_select.on_trait_change(papertype_visibility, 'value')
+        self.file_format_select.observe(papertype_visibility, names='value')
 
         def set_extension(name, value):
             file_name, file_extension = splitext(self.filename_text.value)
             self.filename_text.value = file_name + '.' + value
-        self.file_format_select.on_trait_change(set_extension, 'value')
+        self.file_format_select.observe(set_extension, names='value')
 
         def save_function(name):
             # set save button state
@@ -2918,8 +2912,8 @@ class FeatureOptionsWidget(ipywidgets.FlexBox):
                     if f == value:
                         self.no_options_widget.value = \
                             "{}: No available options.".format(name)
-        self.feature_radiobuttons.on_trait_change(
-            per_feature_options_visibility, 'value')
+        self.feature_radiobuttons.observe(
+            per_feature_options_visibility, names='value')
         per_feature_options_visibility('', no_op)
 
         def get_function(name, value):
@@ -2942,8 +2936,8 @@ class FeatureOptionsWidget(ipywidgets.FlexBox):
             self.function = func
             self.features_function = value
             self.features_options = opts
-        self.feature_radiobuttons.on_trait_change(get_function, 'value')
-        self.options_box.on_trait_change(get_function, 'selected_index')
+        self.feature_radiobuttons.observe(get_function, names='value')
+        self.options_box.observe(get_function, 'selected_index')
 
         def preview_function(name, old_value, value):
             if value == 2:
@@ -2982,7 +2976,7 @@ class FeatureOptionsWidget(ipywidgets.FlexBox):
             if old_value == 2:
                 self.preview_input_latex.visible = False
                 self.preview_image.visible = False
-        self.options_box.on_trait_change(preview_function, 'selected_index')
+        self.options_box.observe(preview_function, 'selected_index')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -3280,8 +3274,8 @@ class PatchOptionsWidget(MenpoWidget):
                 self.background_toggle.description = 'black'
                 self.background_toggle.background_colour = '#000000'
                 self.background_toggle.color = '#FFFFFF'
-        self.background_toggle.on_trait_change(change_toggle_description,
-                                               'value')
+        self.background_toggle.observe(change_toggle_description,
+                                       names='value')
 
         self.background_title = ipywidgets.Latex(value='Background:',
                                                  margin='0.1cm')
@@ -3320,30 +3314,26 @@ class PatchOptionsWidget(MenpoWidget):
         self.predefined_style(style, subwidgets_style)
 
     def add_callbacks(self):
-        self.slicing_wid.on_trait_change(self._save_options, 'selected_values')
-        self.offset_dropdown.on_trait_change(self._save_options, 'value')
-        self.background_toggle.on_trait_change(self._save_options, 'value')
-        self.render_patches_checkbox.on_trait_change(self._save_options,
-                                                     'value')
-        self.render_centers_checkbox.on_trait_change(self._save_options,
-                                                     'value')
-        self.bboxes_line_options_wid.on_trait_change(self._save_options,
-                                                     'selected_values')
+        self.slicing_wid.observe(self._save_options, names='selected_values')
+        self.offset_dropdown.observe(self._save_options, names='value')
+        self.background_toggle.observe(self._save_options, names='value')
+        self.render_patches_checkbox.observe(self._save_options,
+                                             names='value')
+        self.render_centers_checkbox.observe(self._save_options,
+                                             names='value')
+        self.bboxes_line_options_wid.observe(self._save_options,
+                                             names='selected_values')
 
     def remove_callbacks(self):
-        self.slicing_wid.on_trait_change(self._save_options, 'selected_values',
-                                         remove=True)
-        self.offset_dropdown.on_trait_change(self._save_options, 'value',
-                                             remove=True)
-        self.background_toggle.on_trait_change(self._save_options, 'value',
-                                               remove=True)
-        self.render_patches_checkbox.on_trait_change(self._save_options,
-                                                     'value', remove=True)
-        self.render_centers_checkbox.on_trait_change(self._save_options,
-                                                     'value', remove=True)
-        self.bboxes_line_options_wid.on_trait_change(self._save_options,
-                                                     'selected_values',
-                                                     remove=True)
+        self.slicing_wid.observe(self._save_options, names='selected_values')
+        self.offset_dropdown.observe(self._save_options, names='value')
+        self.background_toggle.observe(self._save_options, names='value')
+        self.render_patches_checkbox.observe(self._save_options,
+                                             names='value')
+        self.render_centers_checkbox.observe(self._save_options,
+                                             names='value')
+        self.bboxes_line_options_wid.observe(self._save_options,
+                                             names='selected_values')
 
     def _save_options(self, name, value):
         # set background attributes
@@ -4008,7 +3998,7 @@ class PlotOptionsWidget(MenpoWidget):
             if self.curves_dropdown.value == 0 and self.n_curves > 1:
                 self.curves_dropdown.value = 1
             self.curves_dropdown.value = 0
-        self.legend_entries_text.on_trait_change(get_legend_entries, 'value')
+        self.legend_entries_text.observe(get_legend_entries, names='value')
 
         def save_options(name, value):
             # get lines and markers options
@@ -4075,25 +4065,23 @@ class PlotOptionsWidget(MenpoWidget):
                 'render_grid': self.grid_wid.selected_values['render_grid'],
                 'grid_line_style': self.grid_wid.selected_values['grid_line_style'],
                 'grid_line_width': self.grid_wid.selected_values['grid_line_width']}
-        self.title.on_trait_change(save_options, 'value')
-        self.x_label.on_trait_change(save_options, 'value')
-        self.y_label.on_trait_change(save_options, 'value')
-        self.legend_entries_text.on_trait_change(save_options, 'value')
-        self.lines_wid.on_trait_change(save_options, 'selected_values')
-        self.markers_wid.on_trait_change(save_options, 'selected_values')
-        self.axes_wid.on_trait_change(save_options, 'selected_values')
-        self.legend_wid.on_trait_change(save_options, 'selected_values')
-        self.grid_wid.on_trait_change(save_options, 'selected_values')
-        self.zoom_wid.on_trait_change(save_options, 'selected_values')
+        self.title.observe(save_options, names='value')
+        self.x_label.observe(save_options, names='value')
+        self.y_label.observe(save_options, names='value')
+        self.legend_entries_text.observe(save_options, names='value')
+        self.lines_wid.observe(save_options, names='selected_values')
+        self.markers_wid.observe(save_options, names='selected_values')
+        self.axes_wid.observe(save_options, names='selected_values')
+        self.legend_wid.observe(save_options, names='selected_values')
+        self.grid_wid.observe(save_options, names='selected_values')
+        self.zoom_wid.observe(save_options, names='selected_values')
 
         def update_lines_markers(name, value):
             k = self.curves_dropdown.value
 
             # remove save options callback
-            self.lines_wid.on_trait_change(save_options, 'selected_values',
-                                           remove=True)
-            self.markers_wid.on_trait_change(save_options, 'selected_values',
-                                             remove=True)
+            self.lines_wid.observe(save_options, names='selected_values')
+            self.markers_wid.observe(save_options, names='selected_values')
 
             # update lines
             self.lines_wid.set_widget_state(
@@ -4113,9 +4101,9 @@ class PlotOptionsWidget(MenpoWidget):
                 labels=None, allow_callback=False)
 
             # add save options callback
-            self.lines_wid.on_trait_change(save_options, 'selected_values')
-            self.markers_wid.on_trait_change(save_options, 'selected_values')
-        self.curves_dropdown.on_trait_change(update_lines_markers, 'value')
+            self.lines_wid.observe(save_options, names='selected_values')
+            self.markers_wid.observe(save_options, names='selected_values')
+        self.curves_dropdown.observe(update_lines_markers, names='value')
 
     def create_default_options(self):
         render_lines = [True] * self.n_curves
@@ -4605,7 +4593,7 @@ class LinearModelParametersWidget(MenpoWidget):
                 current_parameters = list(self.selected_values)
                 current_parameters[self.dropdown_params.value] = value
                 self.selected_values = current_parameters
-            self.slider.on_trait_change(save_slider_value, 'value')
+            self.slider.observe(save_slider_value, names='value')
 
             # Set correct value to slider when drop down menu value changes
             def set_slider_value(name, value):
@@ -4616,7 +4604,7 @@ class LinearModelParametersWidget(MenpoWidget):
                 self.slider.value = self.parameters[value]
                 # Re-assign render callback
                 self.add_render_function(render_function)
-            self.dropdown_params.on_trait_change(set_slider_value, 'value')
+            self.dropdown_params.observe(set_slider_value, names='value')
         else:
             # Assign slider value to parameters values list
             def save_slider_value_from_id(description, name, value):
@@ -4638,7 +4626,7 @@ class LinearModelParametersWidget(MenpoWidget):
                 # that creates a new lexical scoping so that we can ensure the
                 # value of w is maintained (as x) at each iteration.
                 # In JavaScript, we would just use the 'let' keyword...
-                w.on_trait_change(partial_widget(w.description), 'value')
+                w.observe(partial_widget(w.description), names='value')
 
         def reset_parameters(name):
             # Temporarily remove render callback
@@ -4950,7 +4938,7 @@ class LinearModelParametersWidget(MenpoWidget):
                     # ensure the value of w is maintained (as x) at each
                     # iteration. In JavaScript, we would just use the 'let'
                     # keyword...
-                    w.on_trait_change(partial_widget(w.description), 'value')
+                    w.observe(partial_widget(w.description), names='value')
 
                 # Set style
                 if self.box_style is None:

--- a/menpowidgets/tools.py
+++ b/menpowidgets/tools.py
@@ -416,14 +416,14 @@ class SlicingCommandWidget(MenpoWidget):
         def single_slider_value(name, value):
             self.selected_values = [value]
             self.cmd_text.value = str(value)
-        self.single_slider.on_trait_change(single_slider_value, 'value')
+        self.single_slider.observe(single_slider_value, names='value')
 
-        def multiple_slider_value(name, value):
+        def multiple_slider_value(value):
             self.selected_values = list(range(value[0], value[1]+1,
                                               self.multiple_slider.step))
             self.cmd_text.value = "{}:{}:{}".format(value[0], value[1]+1,
                                                     self.multiple_slider.step)
-        self.multiple_slider.on_trait_change(multiple_slider_value, 'value')
+        self.multiple_slider.observe(multiple_slider_value, names='value')
 
     def _single_slider_visible(self, selected_values):
         return len(selected_values) == 1
@@ -613,7 +613,7 @@ class IndexSliderWidget(MenpoWidget):
         # Set functionality
         def save_index(name, value):
             self.selected_values = value
-        self.slider.on_trait_change(save_index, 'value')
+        self.slider.observe(save_index, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -810,7 +810,7 @@ class IndexButtonsWidget(MenpoWidget):
 
         def save_index(name, value):
             self.selected_values = int(value)
-        self.index_text.on_trait_change(save_index, 'value')
+        self.index_text.observe(save_index, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -1029,14 +1029,14 @@ class ColourSelectionWidget(MenpoWidget):
         def update_colour_wrt_label(name, value):
             self.colour_widget.value = decode_colour(
                 self.selected_values[value])
-        self.label_dropdown.on_trait_change(update_colour_wrt_label, 'value')
+        self.label_dropdown.observe(update_colour_wrt_label, names='value')
 
         def save_colour(name, value):
             idx = self.label_dropdown.value
             tmp = [v for v in self.selected_values]
             tmp[idx] = str(self.colour_widget.value)
             self.selected_values = tmp
-        self.colour_widget.on_trait_change(save_colour, 'value')
+        self.colour_widget.observe(save_colour, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -1293,7 +1293,7 @@ class ZoomOneScaleWidget(MenpoWidget):
 
         def save_zoom_slider(name, value):
             self.selected_values = value
-        self.zoom_slider.on_trait_change(save_zoom_slider, 'value')
+        self.zoom_slider.observe(save_zoom_slider, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -1549,8 +1549,8 @@ class ZoomTwoScalesWidget(MenpoWidget):
             else:
                 self.selected_values = [self.x_zoom_slider.value,
                                         self.y_zoom_slider.value]
-        self.x_zoom_slider.on_trait_change(save_zoom, 'value')
-        self.y_zoom_slider.on_trait_change(save_zoom, 'value')
+        self.x_zoom_slider.observe(save_zoom, names='value')
+        self.y_zoom_slider.observe(save_zoom, names='value')
 
         def link_button(name, value):
             self.lock_aspect_ratio = value
@@ -1563,7 +1563,7 @@ class ZoomTwoScalesWidget(MenpoWidget):
             else:
                 self.lock_aspect_button.icon = 'fa-unlink'
                 self.lock_link.unlink()
-        self.lock_aspect_button.on_trait_change(link_button, 'value')
+        self.lock_aspect_button.observe(link_button, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -1795,21 +1795,21 @@ class ImageOptionsWidget(MenpoWidget):
             self.selected_values = {'interpolation': interpolation,
                                     'alpha': tmp['alpha'],
                                     'cmap_name': tmp['cmap_name']}
-        self.interpolation_checkbox.on_trait_change(save_interpolation, 'value')
+        self.interpolation_checkbox.observe(save_interpolation, names='value')
 
         def save_alpha(name, value):
             tmp = self.selected_values
             self.selected_values = {'interpolation': tmp['interpolation'],
                                     'alpha': value,
                                     'cmap_name': tmp['cmap_name']}
-        self.alpha_slider.on_trait_change(save_alpha, 'value')
+        self.alpha_slider.observe(save_alpha, names='value')
 
         def save_cmap(name, value):
             tmp = self.selected_values
             self.selected_values = {'interpolation': tmp['interpolation'],
                                     'alpha': tmp['alpha'],
                                     'cmap_name': value}
-        self.cmap_select.on_trait_change(save_cmap, 'value')
+        self.cmap_select.observe(save_cmap, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -1972,8 +1972,8 @@ class LineOptionsWidget(MenpoWidget):
         def line_options_visible(name, value):
             self.line_options_box.visible = value
         line_options_visible('', line_options['render_lines'])
-        self.render_lines_checkbox.on_trait_change(line_options_visible,
-                                                   'value')
+        self.render_lines_checkbox.observe(line_options_visible,
+                                                   names='value')
 
         def save_options(name, value):
             self.selected_values = {
@@ -1981,10 +1981,10 @@ class LineOptionsWidget(MenpoWidget):
                 'line_width': float(self.line_width_text.value),
                 'line_colour': self.line_colour_widget.selected_values,
                 'line_style': self.line_style_dropdown.value}
-        self.render_lines_checkbox.on_trait_change(save_options, 'value')
-        self.line_width_text.on_trait_change(save_options, 'value')
-        self.line_colour_widget.on_trait_change(save_options, 'selected_values')
-        self.line_style_dropdown.on_trait_change(save_options, 'value')
+        self.render_lines_checkbox.observe(save_options, names='value')
+        self.line_width_text.observe(save_options, names='value')
+        self.line_colour_widget.observe(save_options, names='selected_values')
+        self.line_style_dropdown.observe(save_options, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -2189,8 +2189,8 @@ class MarkerOptionsWidget(MenpoWidget):
         def marker_options_visible(name, value):
             self.marker_options_box.visible = value
         marker_options_visible('', marker_options['render_markers'])
-        self.render_markers_checkbox.on_trait_change(marker_options_visible,
-                                                     'value')
+        self.render_markers_checkbox.observe(marker_options_visible,
+                                                     names='value')
 
         def save_options(name, value):
             self.selected_values = {
@@ -2202,14 +2202,14 @@ class MarkerOptionsWidget(MenpoWidget):
                     self.marker_edge_colour_widget.selected_values,
                 'marker_style': self.marker_style_dropdown.value,
                 'marker_edge_width': float(self.marker_edge_width_text.value)}
-        self.render_markers_checkbox.on_trait_change(save_options, 'value')
-        self.marker_size_text.on_trait_change(save_options, 'value')
-        self.marker_face_colour_widget.on_trait_change(save_options,
-                                                       'selected_values')
-        self.marker_edge_colour_widget.on_trait_change(save_options,
-                                                       'selected_values')
-        self.marker_style_dropdown.on_trait_change(save_options, 'value')
-        self.marker_edge_width_text.on_trait_change(save_options, 'value')
+        self.render_markers_checkbox.observe(save_options, names='value')
+        self.marker_size_text.observe(save_options, names='value')
+        self.marker_face_colour_widget.observe(save_options,
+                                                       names='selected_values')
+        self.marker_edge_colour_widget.observe(save_options,
+                                                       names='selected_values')
+        self.marker_style_dropdown.observe(save_options, names='value')
+        self.marker_edge_width_text.observe(save_options, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -2450,8 +2450,8 @@ class NumberingOptionsWidget(MenpoWidget):
         def numbering_options_visible(name, value):
             self.numbering_options_box.visible = value
         numbering_options_visible('', numbers_options['render_numbering'])
-        self.render_numbering_checkbox.on_trait_change(
-            numbering_options_visible, 'value')
+        self.render_numbering_checkbox.observe(
+            numbering_options_visible, names='value')
 
         def save_options(name, value):
             self.selected_values = {
@@ -2466,17 +2466,17 @@ class NumberingOptionsWidget(MenpoWidget):
                     self.numbers_horizontal_align_dropdown.value,
                 'numbers_vertical_align':
                     self.numbers_vertical_align_dropdown.value}
-        self.render_numbering_checkbox.on_trait_change(save_options, 'value')
-        self.numbers_font_name_dropdown.on_trait_change(save_options, 'value')
-        self.numbers_font_size_text.on_trait_change(save_options, 'value')
-        self.numbers_font_style_dropdown.on_trait_change(save_options, 'value')
-        self.numbers_font_weight_dropdown.on_trait_change(save_options, 'value')
-        self.numbers_font_colour_widget.on_trait_change(save_options,
-                                                        'selected_values')
-        self.numbers_horizontal_align_dropdown.on_trait_change(save_options,
-                                                               'value')
-        self.numbers_vertical_align_dropdown.on_trait_change(save_options,
-                                                             'value')
+        self.render_numbering_checkbox.observe(save_options, names='value')
+        self.numbers_font_name_dropdown.observe(save_options, names='value')
+        self.numbers_font_size_text.observe(save_options, names='value')
+        self.numbers_font_style_dropdown.observe(save_options, names='value')
+        self.numbers_font_weight_dropdown.observe(save_options, names='value')
+        self.numbers_font_colour_widget.observe(save_options,
+                                                        names='selected_values')
+        self.numbers_horizontal_align_dropdown.observe(save_options,
+                                                               names='value')
+        self.numbers_vertical_align_dropdown.observe(save_options,
+                                                             names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -2716,7 +2716,7 @@ class AxesLimitsWidget(MenpoWidget):
             else:
                 self.axes_x_limits_percentage.visible = False
                 self.axes_x_limits_range.visible = True
-        self.axes_x_limits_toggles.on_trait_change(x_visibility, 'value')
+        self.axes_x_limits_toggles.observe(x_visibility, names='value')
 
         def y_visibility(name, value):
             if value == 'auto':
@@ -2728,7 +2728,7 @@ class AxesLimitsWidget(MenpoWidget):
             else:
                 self.axes_y_limits_percentage.visible = False
                 self.axes_y_limits_range.visible = True
-        self.axes_y_limits_toggles.on_trait_change(y_visibility, 'value')
+        self.axes_y_limits_toggles.observe(y_visibility, names='value')
 
         def save_options(name, value):
             if self.axes_x_limits_toggles.value == 'auto':
@@ -2744,16 +2744,16 @@ class AxesLimitsWidget(MenpoWidget):
             else:
                 y_val = self.axes_y_limits_range.selected_values
             self.selected_values = {'x': x_val, 'y': y_val}
-        self.axes_x_limits_toggles.on_trait_change(save_options, 'value')
-        self.axes_x_limits_percentage.on_trait_change(save_options,
-                                                      'selected_values')
-        self.axes_x_limits_range.on_trait_change(save_options,
-                                                 'selected_values')
-        self.axes_y_limits_toggles.on_trait_change(save_options, 'value')
-        self.axes_y_limits_percentage.on_trait_change(save_options,
-                                                      'selected_values')
-        self.axes_y_limits_range.on_trait_change(save_options,
-                                                 'selected_values')
+        self.axes_x_limits_toggles.observe(save_options, names='value')
+        self.axes_x_limits_percentage.observe(save_options,
+                                                      names='selected_values')
+        self.axes_x_limits_range.observe(save_options,
+                                                 names='selected_values')
+        self.axes_y_limits_toggles.observe(save_options, names='value')
+        self.axes_y_limits_percentage.observe(save_options,
+                                                      names='selected_values')
+        self.axes_y_limits_range.observe(save_options,
+                                                 names='selected_values')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -2965,11 +2965,11 @@ class AxesTicksWidget(MenpoWidget):
         # Set functionality
         def x_visibility(name, value):
             self.axes_x_ticks_list.visible = value == 'list'
-        self.axes_x_ticks_toggles.on_trait_change(x_visibility, 'value')
+        self.axes_x_ticks_toggles.observe(x_visibility, names='value')
 
         def y_visibility(name, value):
             self.axes_y_ticks_list.visible = value == 'list'
-        self.axes_y_ticks_toggles.on_trait_change(y_visibility, 'value')
+        self.axes_y_ticks_toggles.observe(y_visibility, names='value')
 
         def save_options(name, value):
             if self.axes_x_ticks_toggles.value == 'auto':
@@ -2981,10 +2981,10 @@ class AxesTicksWidget(MenpoWidget):
             else:
                 y_val = self.axes_y_ticks_list.selected_values
             self.selected_values = {'x': x_val, 'y': y_val}
-        self.axes_x_ticks_toggles.on_trait_change(save_options, 'value')
-        self.axes_x_ticks_list.on_trait_change(save_options, 'selected_values')
-        self.axes_y_ticks_toggles.on_trait_change(save_options, 'value')
-        self.axes_y_ticks_list.on_trait_change(save_options, 'selected_values')
+        self.axes_x_ticks_toggles.observe(save_options, names='value')
+        self.axes_x_ticks_list.observe(save_options, names='selected_values')
+        self.axes_y_ticks_toggles.observe(save_options, names='value')
+        self.axes_y_ticks_list.observe(save_options, names='selected_values')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -3221,8 +3221,8 @@ class AxesOptionsWidget(MenpoWidget):
         def axes_options_visible(name, value):
             self.axes_font_ticks_options.visible = value
         axes_options_visible('', axes_options['render_axes'])
-        self.render_axes_checkbox.on_trait_change(axes_options_visible,
-                                                  'value')
+        self.render_axes_checkbox.observe(axes_options_visible,
+                                                  names='value')
 
         def save_options(name, value):
             self.selected_values = {
@@ -3235,13 +3235,13 @@ class AxesOptionsWidget(MenpoWidget):
                 'axes_y_ticks': self.axes_ticks_widget.selected_values['y'],
                 'axes_x_limits': self.axes_limits_widget.selected_values['x'],
                 'axes_y_limits': self.axes_limits_widget.selected_values['y']}
-        self.render_axes_checkbox.on_trait_change(save_options, 'value')
-        self.axes_font_name_dropdown.on_trait_change(save_options, 'value')
-        self.axes_font_size_text.on_trait_change(save_options, 'value')
-        self.axes_font_style_dropdown.on_trait_change(save_options, 'value')
-        self.axes_font_weight_dropdown.on_trait_change(save_options, 'value')
-        self.axes_ticks_widget.on_trait_change(save_options, 'selected_values')
-        self.axes_limits_widget.on_trait_change(save_options, 'selected_values')
+        self.render_axes_checkbox.observe(save_options, names='value')
+        self.axes_font_name_dropdown.observe(save_options, names='value')
+        self.axes_font_size_text.observe(save_options, names='value')
+        self.axes_font_style_dropdown.observe(save_options, names='value')
+        self.axes_font_weight_dropdown.observe(save_options, names='value')
+        self.axes_ticks_widget.observe(save_options, names='selected_values')
+        self.axes_limits_widget.observe(save_options, names='selected_values')
 
     def set_widget_state(self, axes_options, allow_callback=True):
         r"""
@@ -3571,20 +3571,20 @@ class LegendOptionsWidget(MenpoWidget):
         def legend_options_visible(name, value):
             self.tab_box.visible = value
         legend_options_visible('', legend_options['render_legend'])
-        self.render_legend_checkbox.on_trait_change(legend_options_visible,
-                                                    'value')
+        self.render_legend_checkbox.observe(legend_options_visible,
+                                                    names='value')
 
         def border_pad_visible(name, value):
             self.legend_border_padding_text.visible = value
-        self.legend_border_checkbox.on_trait_change(border_pad_visible, 'value')
+        self.legend_border_checkbox.observe(border_pad_visible, names='value')
 
         def bbox_to_anchor_visible(name, value):
             self.bbox_to_anchor_x_text.visible = value
             self.bbox_to_anchor_y_text.visible = value
         bbox_to_anchor_visible('', not legend_options['legend_bbox_to_anchor']
                                is None)
-        self.bbox_to_anchor_enable_checkbox.on_trait_change(
-            bbox_to_anchor_visible, 'value')
+        self.bbox_to_anchor_enable_checkbox.observe(
+            bbox_to_anchor_visible, names='value')
 
         def save_options(name, value):
             legend_bbox_to_anchor = None
@@ -3615,28 +3615,28 @@ class LegendOptionsWidget(MenpoWidget):
                 'legend_shadow': self.legend_shadow_checkbox.value,
                 'legend_rounded_corners':
                     self.legend_rounded_corners_checkbox.value}
-        self.render_legend_checkbox.on_trait_change(save_options, 'value')
-        self.legend_title_text.on_trait_change(save_options, 'value')
-        self.legend_font_name_dropdown.on_trait_change(save_options, 'value')
-        self.legend_font_size_text.on_trait_change(save_options, 'value')
-        self.legend_font_style_dropdown.on_trait_change(save_options, 'value')
-        self.legend_font_weight_dropdown.on_trait_change(save_options, 'value')
-        self.legend_location_dropdown.on_trait_change(save_options, 'value')
-        self.bbox_to_anchor_enable_checkbox.on_trait_change(save_options,
-                                                            'value')
-        self.bbox_to_anchor_x_text.on_trait_change(save_options, 'value')
-        self.bbox_to_anchor_y_text.on_trait_change(save_options, 'value')
-        self.legend_border_axes_pad_text.on_trait_change(save_options, 'value')
-        self.legend_n_columns_text.on_trait_change(save_options, 'value')
-        self.legend_marker_scale_text.on_trait_change(save_options, 'value')
-        self.legend_horizontal_spacing_text.on_trait_change(save_options,
-                                                            'value')
-        self.legend_vertical_spacing_text.on_trait_change(save_options, 'value')
-        self.legend_border_checkbox.on_trait_change(save_options, 'value')
-        self.legend_border_padding_text.on_trait_change(save_options, 'value')
-        self.legend_shadow_checkbox.on_trait_change(save_options, 'value')
-        self.legend_rounded_corners_checkbox.on_trait_change(save_options,
-                                                             'value')
+        self.render_legend_checkbox.observe(save_options, names='value')
+        self.legend_title_text.observe(save_options, names='value')
+        self.legend_font_name_dropdown.observe(save_options, names='value')
+        self.legend_font_size_text.observe(save_options, names='value')
+        self.legend_font_style_dropdown.observe(save_options, names='value')
+        self.legend_font_weight_dropdown.observe(save_options, names='value')
+        self.legend_location_dropdown.observe(save_options, names='value')
+        self.bbox_to_anchor_enable_checkbox.observe(save_options,
+                                                            names='value')
+        self.bbox_to_anchor_x_text.observe(save_options, names='value')
+        self.bbox_to_anchor_y_text.observe(save_options, names='value')
+        self.legend_border_axes_pad_text.observe(save_options, names='value')
+        self.legend_n_columns_text.observe(save_options, names='value')
+        self.legend_marker_scale_text.observe(save_options, names='value')
+        self.legend_horizontal_spacing_text.observe(save_options,
+                                                            names='value')
+        self.legend_vertical_spacing_text.observe(save_options, names='value')
+        self.legend_border_checkbox.observe(save_options, names='value')
+        self.legend_border_padding_text.observe(save_options, names='value')
+        self.legend_shadow_checkbox.observe(save_options, names='value')
+        self.legend_rounded_corners_checkbox.observe(save_options,
+                                                             names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -3900,16 +3900,16 @@ class GridOptionsWidget(MenpoWidget):
         def grid_options_visible(name, value):
             self.grid_options_box.visible = value
         grid_options_visible('', grid_options['render_grid'])
-        self.render_grid_checkbox.on_trait_change(grid_options_visible, 'value')
+        self.render_grid_checkbox.observe(grid_options_visible, names='value')
 
         def save_options(name, value):
             self.selected_values = {
                 'render_grid': self.render_grid_checkbox.value,
                 'grid_line_width': float(self.grid_line_width_text.value),
                 'grid_line_style': self.grid_line_style_dropdown.value}
-        self.render_grid_checkbox.on_trait_change(save_options, 'value')
-        self.grid_line_width_text.on_trait_change(save_options, 'value')
-        self.grid_line_style_dropdown.on_trait_change(save_options, 'value')
+        self.render_grid_checkbox.observe(save_options, names='value')
+        self.grid_line_width_text.observe(save_options, names='value')
+        self.grid_line_style_dropdown.observe(save_options, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -4139,7 +4139,7 @@ class HOGOptionsWidget(MenpoWidget):
             self.window_height_text.disabled = value == 'sparse'
             self.window_width_text.disabled = value == 'sparse'
             self.window_size_unit_radiobuttons.disabled = value == 'sparse'
-        self.mode_radiobuttons.on_trait_change(window_mode, 'value')
+        self.mode_radiobuttons.observe(window_mode, names='value')
 
         # algorithm function
         def algorithm_mode(name, value):
@@ -4147,7 +4147,7 @@ class HOGOptionsWidget(MenpoWidget):
             self.signed_gradient_checkbox.disabled = value == 'zhuramanan'
             self.block_size_text.disabled = value == 'zhuramanan'
             self.num_bins_text.disabled = value == 'zhuramanan'
-        self.algorithm_radiobuttons.on_trait_change(algorithm_mode, 'value')
+        self.algorithm_radiobuttons.observe(algorithm_mode, names='value')
 
         # get options
         def save_options(name, value):
@@ -4166,22 +4166,22 @@ class HOGOptionsWidget(MenpoWidget):
                 'window_step_horizontal': self.window_horizontal_text.value,
                 'window_step_unit': self.window_step_unit_radiobuttons.value,
                 'padding': self.padding_checkbox.value}
-        self.mode_radiobuttons.on_trait_change(save_options, 'value')
-        self.padding_checkbox.on_trait_change(save_options, 'value')
-        self.window_height_text.on_trait_change(save_options, 'value')
-        self.window_width_text.on_trait_change(save_options, 'value')
-        self.window_size_unit_radiobuttons.on_trait_change(save_options,
-                                                           'value')
-        self.window_vertical_text.on_trait_change(save_options, 'value')
-        self.window_horizontal_text.on_trait_change(save_options, 'value')
-        self.window_step_unit_radiobuttons.on_trait_change(save_options,
-                                                           'value')
-        self.algorithm_radiobuttons.on_trait_change(save_options, 'value')
-        self.num_bins_text.on_trait_change(save_options, 'value')
-        self.cell_size_text.on_trait_change(save_options, 'value')
-        self.block_size_text.on_trait_change(save_options, 'value')
-        self.signed_gradient_checkbox.on_trait_change(save_options, 'value')
-        self.l2_norm_clipping_text.on_trait_change(save_options, 'value')
+        self.mode_radiobuttons.observe(save_options, names='value')
+        self.padding_checkbox.observe(save_options, names='value')
+        self.window_height_text.observe(save_options, names='value')
+        self.window_width_text.observe(save_options, names='value')
+        self.window_size_unit_radiobuttons.observe(save_options,
+                                                           names='value')
+        self.window_vertical_text.observe(save_options, names='value')
+        self.window_horizontal_text.observe(save_options, names='value')
+        self.window_step_unit_radiobuttons.observe(save_options,
+                                                           names='value')
+        self.algorithm_radiobuttons.observe(save_options, names='value')
+        self.num_bins_text.observe(save_options, names='value')
+        self.cell_size_text.observe(save_options, names='value')
+        self.block_size_text.observe(save_options, names='value')
+        self.signed_gradient_checkbox.observe(save_options, names='value')
+        self.l2_norm_clipping_text.observe(save_options, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -4353,14 +4353,14 @@ class DSIFTOptionsWidget(MenpoWidget):
                 'cell_size_horizontal': self.cell_size_horizontal_text.value,
                 'cell_size_vertical': self.cell_size_vertical_text.value,
                 'fast': self.fast_checkbox.value}
-        self.window_vertical_text.on_trait_change(save_options, 'value')
-        self.window_horizontal_text.on_trait_change(save_options, 'value')
-        self.num_bins_vertical_text.on_trait_change(save_options, 'value')
-        self.num_bins_horizontal_text.on_trait_change(save_options, 'value')
-        self.num_or_bins_text.on_trait_change(save_options, 'value')
-        self.cell_size_vertical_text.on_trait_change(save_options, 'value')
-        self.cell_size_horizontal_text.on_trait_change(save_options, 'value')
-        self.fast_checkbox.on_trait_change(save_options, 'value')
+        self.window_vertical_text.observe(save_options, names='value')
+        self.window_horizontal_text.observe(save_options, names='value')
+        self.num_bins_vertical_text.observe(save_options, names='value')
+        self.num_bins_horizontal_text.observe(save_options, names='value')
+        self.num_or_bins_text.observe(save_options, names='value')
+        self.cell_size_vertical_text.observe(save_options, names='value')
+        self.cell_size_horizontal_text.observe(save_options, names='value')
+        self.fast_checkbox.observe(save_options, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -4529,14 +4529,14 @@ class DaisyOptionsWidget(MenpoWidget):
                 'normalization': self.normalization_dropdown.value,
                 'sigmas': sigmas_val,
                 'ring_radii': ring_radii_val}
-        self.step_text.on_trait_change(save_options, 'value')
-        self.radius_text.on_trait_change(save_options, 'value')
-        self.rings_text.on_trait_change(save_options, 'value')
-        self.histograms_text.on_trait_change(save_options, 'value')
-        self.orientations_text.on_trait_change(save_options, 'value')
-        self.normalization_dropdown.on_trait_change(save_options, 'value')
-        self.sigmas_wid.on_trait_change(save_options, 'selected_values')
-        self.ring_radii_wid.on_trait_change(save_options, 'selected_values')
+        self.step_text.observe(save_options, names='value')
+        self.radius_text.observe(save_options, names='value')
+        self.rings_text.observe(save_options, names='value')
+        self.histograms_text.observe(save_options, names='value')
+        self.orientations_text.observe(save_options, names='value')
+        self.normalization_dropdown.observe(save_options, names='value')
+        self.sigmas_wid.observe(save_options, names='selected_values')
+        self.ring_radii_wid.observe(save_options, names='selected_values')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -4692,14 +4692,14 @@ class LBPOptionsWidget(MenpoWidget):
                 'window_step_horizontal': self.window_horizontal_text.value,
                 'window_step_unit': self.window_step_unit_radiobuttons.value,
                 'padding': self.padding_checkbox.value}
-        self.mapping_type_dropdown.on_trait_change(save_options, 'value')
-        self.window_vertical_text.on_trait_change(save_options, 'value')
-        self.window_horizontal_text.on_trait_change(save_options, 'value')
-        self.window_step_unit_radiobuttons.on_trait_change(save_options,
-                                                           'value')
-        self.padding_checkbox.on_trait_change(save_options, 'value')
-        self.radius_wid.on_trait_change(save_options, 'selected_values')
-        self.samples_wid.on_trait_change(save_options, 'selected_values')
+        self.mapping_type_dropdown.observe(save_options, names='value')
+        self.window_vertical_text.observe(save_options, names='value')
+        self.window_horizontal_text.observe(save_options, names='value')
+        self.window_step_unit_radiobuttons.observe(save_options,
+                                                           names='value')
+        self.padding_checkbox.observe(save_options, names='value')
+        self.radius_wid.observe(save_options, names='selected_values')
+        self.samples_wid.observe(save_options, names='selected_values')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -4805,7 +4805,7 @@ class IGOOptionsWidget(MenpoWidget):
         # Set functionality
         def save_options(name, value):
             self.selected_values = {'double_angles': value}
-        self.double_angles_checkbox.on_trait_change(save_options, 'value')
+        self.double_angles_checkbox.observe(save_options, names='value')
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,


### PR DESCRIPTION
It seems that `on_trait_change` has been deprecated and the
implementation of observing and unobserving has become
much more strict. This makes sure that we only observe and
unobserve when necessary (for the Exceptions thrown by the
`visualize_images` widget). Other widgets may also be broken.
We also need to stop using `on_trait_change` and possibly
investigate if the widgets are much slower now.
