### PR TITLE
Fixing breaking change in traitlets 4.1.0

### DIFF
--- a/menpowidgets/abstract.py
+++ b/menpowidgets/abstract.py
@@ -64,8 +64,9 @@ class MenpoWidget(ipywidgets.FlexBox):
         Method that removes the current `self._render_function()` from the
         widget and sets ``self._render_function = None``.
         """
-        self.on_trait_change(self._render_function, 'selected_values',
-                             remove=True)
+        if self._render_function is not None:
+            self.on_trait_change(self._render_function, 'selected_values',
+                                 remove=True)
         self._render_function = None
 
     def replace_render_function(self, render_function):

--- a/menpowidgets/menpofit/options.py
+++ b/menpowidgets/menpofit/options.py
@@ -181,6 +181,7 @@ class FittingResultOptionsWidget(MenpoWidget):
             self.plot_costs_button.on_click(costs_function)
 
         # Set values
+        self.add_callbacks()
         self.set_widget_state(has_groundtruth, n_iters, allow_callback=False)
 
         # Set style

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -1108,7 +1108,8 @@ class LandmarkOptionsWidget(MenpoWidget):
             children, Dict, {}, render_function=render_function,
             orientation='horizontal', align='start')
 
-        # Set values
+        # Set values, add callbacks before setting widget state
+        self.add_callbacks()
         self.set_widget_state(group_keys, labels_keys, allow_callback=False)
 
         # Set style

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -3314,6 +3314,7 @@ class PatchOptionsWidget(MenpoWidget):
             orientation='horizontal', align='start')
 
         # Set values
+        self.add_callbacks()
         self.set_widget_state(n_patches, n_offsets, allow_callback=False)
 
         # Set style


### PR DESCRIPTION
Now, when you unobserve something you weren't previously
observing, an error is thrown. Therefore, make sure that
we have wired up all the traits before attempting to
remove them.
