### PR TITLE
Update IterativeResultOptionsWidget behaviour

### DIFF
--- a/menpowidgets/menpofit/base.py
+++ b/menpowidgets/menpofit/base.py
@@ -2096,7 +2096,7 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
 
         # get selected view function
         if (fitting_result_wid.result_iterations_tab.selected_index == 0 or
-                not hasattr(fitting_results[im], 'n_iters')):
+                not fitting_results[im].is_iterative):
             # use view()
             # final shape colour
             final_marker_face_colour = tmp1['marker_face_colour'][0]
@@ -2218,7 +2218,7 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
         # Landmarks, scales, iterations
         text_per_line.append(' > {} landmark points.'.format(
                 fr.final_shape.n_points))
-        if hasattr(fr, 'n_iters'):
+        if fr.is_iterative:
             text_per_line.append(' > {} iterations.'.format(fr.n_iters))
         else:
             text_per_line.append(' > No iterations.')
@@ -2302,19 +2302,19 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
         renderer_options_wid.set_widget_state(labels=labels,
                                               allow_callback=False)
 
-    n_iters = None
-    if hasattr(fitting_results[0], 'n_iters'):
-        n_iters = len(fitting_results[0].shapes)
+    n_shapes = None
+    if fitting_results[0].is_iterative:
+        n_shapes = len(fitting_results[0].shapes)
     fitting_result_wid = IterativeResultOptionsWidget(
-            has_gt_shape=fitting_results[0].gt_shape is not None,
-            has_initial_shape=fitting_results[0].initial_shape is not None,
-            has_image=fitting_results[0].image is not None,
-            n_iters=n_iters, render_function=render_function,
-            tab_update_function=update_renderer_options,
-            displacements_function=plot_displacements_function,
-            errors_function=plot_errors_function,
-            costs_function=plot_costs_function, style=fitting_result_style,
-            tabs_style=fitting_result_tabs_style)
+        has_gt_shape=fitting_results[0].gt_shape is not None,
+        has_initial_shape=fitting_results[0].initial_shape is not None,
+        has_image=fitting_results[0].image is not None,
+        n_shapes=n_shapes, render_function=render_function,
+        tab_update_function=update_renderer_options,
+        displacements_function=plot_displacements_function,
+        errors_function=plot_errors_function,
+        costs_function=plot_costs_function, style=fitting_result_style,
+        tabs_style=fitting_result_tabs_style)
 
     # Group widgets
     if n_fitting_results > 1:
@@ -2327,14 +2327,14 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
             im = image_number_wid.selected_values
 
             # Update fitting result options
-            n_iters = None
-            if hasattr(fitting_results[im], 'n_iters'):
-                n_iters = len(fitting_results[im].shapes)
+            n_shapes = None
+            if fitting_results[im].is_iterative:
+                n_shapes = len(fitting_results[im].shapes)
             fitting_result_wid.set_widget_state(
                 has_gt_shape=fitting_results[im].gt_shape is not None,
                 has_initial_shape=fitting_results[im].initial_shape is not None,
                 has_image=fitting_results[im].image is not None,
-                n_iters=n_iters, allow_callback=False)
+                n_shapes=n_shapes, allow_callback=False)
 
             # Update renderer options
             update_renderer_options({})
@@ -2357,10 +2357,10 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
         # Header widget
         header_wid = LogoWidget(style=logo_style)
     # Widget titles
-    tab_titles = ['Info', 'Result', 'Renderer', 'Export']
+    tab_titles = ['Result', 'Info', 'Renderer', 'Export']
     header_wid.margin = '0.2cm'
     options_box = ipywidgets.Tab(
-        children=[info_error_box, fitting_result_wid, renderer_options_wid,
+        children=[fitting_result_wid, info_error_box, renderer_options_wid,
                   save_figure_wid], margin='0.2cm')
     for (k, tl) in enumerate(tab_titles):
         options_box.set_title(k, tl)

--- a/menpowidgets/menpofit/base.py
+++ b/menpowidgets/menpofit/base.py
@@ -2290,12 +2290,12 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
                 labels = None
             else:
                 # The mode is 'Static'
-                n_digits = len(str(fitting_results[im].n_iters))
+                n_digits = len(str(len(fitting_results[im].shapes)))
                 labels = []
-                for j in list(range(fitting_results[im].n_iters + 1)):
+                for j in list(range(len(fitting_results[im].shapes))):
                     if j == 0 and fitting_results[im].initial_shape is not None:
                         labels.append('Initial')
-                    elif j == fitting_results[im].n_iters:
+                    elif j == len(fitting_results[im].shapes) - 1:
                         labels.append('Final')
                     else:
                         labels.append("iteration {:0{}d}".format(j, n_digits))
@@ -2304,7 +2304,7 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
 
     n_iters = None
     if hasattr(fitting_results[0], 'n_iters'):
-        n_iters = fitting_results[0].n_iters
+        n_iters = len(fitting_results[0].shapes)
     fitting_result_wid = IterativeResultOptionsWidget(
             has_gt_shape=fitting_results[0].gt_shape is not None,
             has_initial_shape=fitting_results[0].initial_shape is not None,
@@ -2329,7 +2329,7 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
             # Update fitting result options
             n_iters = None
             if hasattr(fitting_results[im], 'n_iters'):
-                n_iters = fitting_results[im].n_iters
+                n_iters = len(fitting_results[im].shapes)
             fitting_result_wid.set_widget_state(
                 has_gt_shape=fitting_results[im].gt_shape is not None,
                 has_initial_shape=fitting_results[im].initial_shape is not None,

--- a/menpowidgets/menpofit/options.py
+++ b/menpowidgets/menpofit/options.py
@@ -532,12 +532,12 @@ class IterativeResultOptionsWidget(MenpoWidget):
                                      type='change')
         self.iterations_mode.observe(self._index_visibility, names='value',
                                      type='change')
-        index = {'min': 0, 'max': n_iters + 1, 'step': 1, 'index': 0}
+        index = {'min': 0, 'max': n_iters - 1, 'step': 1, 'index': 0}
         self.index_animation = AnimationOptionsWidget(
                 index, description='', index_style='slider',
                 loop_enabled=False, interval=0.)
-        slice_options = {'command': 'range({})'.format(n_iters + 1),
-                         'length': n_iters + 1}
+        slice_options = {'command': 'range({})'.format(n_iters),
+                         'length': n_iters}
         self.index_slicing = SlicingCommandWidget(
                 slice_options, description='', example_visible=True,
                 continuous_update=False, orientation='vertical')
@@ -1040,11 +1040,11 @@ class IterativeResultOptionsWidget(MenpoWidget):
 
             # Update widgets
             if self.n_iters != n_iters and n_iters is not None:
-                index = {'min': 0, 'max': n_iters, 'step': 1, 'index': 0}
+                index = {'min': 0, 'max': n_iters - 1, 'step': 1, 'index': 0}
                 self.index_animation.set_widget_state(index,
                                                       allow_callback=False)
-                slice_options = {'command': 'range({})'.format(n_iters + 1),
-                                 'length': n_iters + 1}
+                slice_options = {'command': 'range({})'.format(n_iters),
+                                 'length': n_iters}
                 self.index_slicing.set_widget_state(slice_options,
                                                     allow_callback=False)
 

--- a/menpowidgets/menpofit/options.py
+++ b/menpowidgets/menpofit/options.py
@@ -392,9 +392,9 @@ class IterativeResultOptionsWidget(MenpoWidget):
         Whether the fitting result object has the initial shape.
     has_image : `bool`
         Whether the fitting result object has the image.
-    n_iters : `int` or ``None``
-        The total number of iterations. If ``None``, then it is assumed that no
-        iterations are available.
+    n_shapes : `int` or ``None``
+        The total number of shapes. If ``None``, then it is assumed that no
+        iteration shapes are available.
     render_function : `callable` or ``None``, optional
         The render function that is executed when a widgets' value changes.
         It must have signature ``render_function(change)`` where ``change`` is
@@ -473,7 +473,7 @@ class IterativeResultOptionsWidget(MenpoWidget):
 
         >>> wid = IterativeResultOptionsWidget(
         >>>         has_gt_shape=True, has_initial_shape=True, has_image=True,
-        >>>         n_iters=20, render_function=render_function,
+        >>>         n_shapes=20, render_function=render_function,
         >>>         displacements_function=plot_function,
         >>>         errors_function=plot_function, costs_function=plot_function,
         >>>         style='info', tabs_style='danger')
@@ -483,10 +483,10 @@ class IterativeResultOptionsWidget(MenpoWidget):
     let's change the widget status with a new set of options:
 
         >>> wid.set_widget_state(has_gt_shape=False, has_initial_shape=True,
-        >>>                      has_image=True, n_iters=None,
+        >>>                      has_image=True, n_shapes=None,
         >>>                      allow_callback=True)
     """
-    def __init__(self, has_gt_shape, has_initial_shape, has_image, n_iters,
+    def __init__(self, has_gt_shape, has_initial_shape, has_image, n_shapes,
                  render_function=None, tab_update_function=None,
                  displacements_function=None, errors_function=None,
                  costs_function=None, style='minimal', tabs_style='minimal'):
@@ -502,7 +502,7 @@ class IterativeResultOptionsWidget(MenpoWidget):
         self.has_gt_shape = None
         self.has_initial_shape = None
         self.has_image = None
-        self.n_iters = -1
+        self.n_shapes = -1
         self.tab_update_function = tab_update_function
 
         # Create result tab
@@ -532,12 +532,12 @@ class IterativeResultOptionsWidget(MenpoWidget):
                                      type='change')
         self.iterations_mode.observe(self._index_visibility, names='value',
                                      type='change')
-        index = {'min': 0, 'max': n_iters - 1, 'step': 1, 'index': 0}
+        index = {'min': 0, 'max': n_shapes - 1, 'step': 1, 'index': 0}
         self.index_animation = AnimationOptionsWidget(
                 index, description='', index_style='slider',
                 loop_enabled=False, interval=0.)
-        slice_options = {'command': 'range({})'.format(n_iters),
-                         'length': n_iters}
+        slice_options = {'command': 'range({})'.format(n_shapes),
+                         'length': n_shapes}
         self.index_slicing = SlicingCommandWidget(
                 slice_options, description='', example_visible=True,
                 continuous_update=False, orientation='vertical')
@@ -600,7 +600,7 @@ class IterativeResultOptionsWidget(MenpoWidget):
         # Set values
         self.add_callbacks()
         self.set_widget_state(has_gt_shape, has_initial_shape, has_image,
-                              n_iters, allow_callback=False)
+                              n_shapes, allow_callback=False)
 
         # Set style
         self.predefined_style(style, tabs_style)
@@ -759,7 +759,7 @@ class IterativeResultOptionsWidget(MenpoWidget):
 
     def _save_options(self, change):
         if (self.result_iterations_tab.selected_index == 0 or
-                self.n_iters is None):
+                self.n_shapes is None):
             # Result tab
             self.selected_values = {
                 'render_final_shape': self.shape_buttons[2].value,
@@ -831,8 +831,8 @@ class IterativeResultOptionsWidget(MenpoWidget):
         self.render_image.visible = self.has_image
         self.plot_errors_button.visible = (self.has_gt_shape and
                                            self._errors_function is not None)
-        self.mode_index_buttons_box.visible = self.n_iters is not None
-        self.no_iterations_text.visible = self.n_iters is None
+        self.mode_index_buttons_box.visible = self.n_shapes is not None
+        self.no_iterations_text.visible = self.n_shapes is None
 
     def style(self, box_style=None, border_visible=False, border_colour='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
@@ -1007,7 +1007,7 @@ class IterativeResultOptionsWidget(MenpoWidget):
                              'danger or warning')
 
     def set_widget_state(self, has_gt_shape, has_initial_shape, has_image,
-                         n_iters, allow_callback=True):
+                         n_shapes, allow_callback=True):
         r"""
         Method that updates the state of the widget with a new set of values.
 
@@ -1019,9 +1019,9 @@ class IterativeResultOptionsWidget(MenpoWidget):
             Whether the fitting result object has the initial shape.
         has_image : `bool`
             Whether the fitting result object has the image.
-        n_iters : `int` or ``None``
-            The total number of iterations. If ``None``, then it is assumed
-            that no iterations are available.
+        n_shapes : `int` or ``None``
+            The total number of shapes. If ``None``, then it is assumed
+            that no iteration shapes are available.
         allow_callback : `bool`, optional
             If ``True``, it allows triggering of any callback functions.
         """
@@ -1032,19 +1032,19 @@ class IterativeResultOptionsWidget(MenpoWidget):
         if (self.has_gt_shape != has_gt_shape or
                 self.has_initial_shape != has_initial_shape or
                 self.has_image != has_image or
-                self.n_iters != n_iters):
+                self.n_shapes != n_shapes):
             # temporarily remove callbacks
             render_function = self._render_function
             self.remove_render_function()
             self.remove_callbacks()
 
             # Update widgets
-            if self.n_iters != n_iters and n_iters is not None:
-                index = {'min': 0, 'max': n_iters - 1, 'step': 1, 'index': 0}
+            if self.n_shapes != n_shapes and n_shapes is not None:
+                index = {'min': 0, 'max': n_shapes - 1, 'step': 1, 'index': 0}
                 self.index_animation.set_widget_state(index,
                                                       allow_callback=False)
-                slice_options = {'command': 'range({})'.format(n_iters),
-                                 'length': n_iters}
+                slice_options = {'command': 'range({})'.format(n_shapes),
+                                 'length': n_shapes}
                 self.index_slicing.set_widget_state(slice_options,
                                                     allow_callback=False)
 
@@ -1052,7 +1052,7 @@ class IterativeResultOptionsWidget(MenpoWidget):
             self.has_gt_shape = has_gt_shape
             self.has_initial_shape = has_initial_shape
             self.has_image = has_image
-            self.n_iters = n_iters
+            self.n_shapes = n_shapes
 
             # Set widget's visibility
             self.set_visibility()

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -435,7 +435,7 @@ class AnimationOptionsWidget(MenpoWidget):
                 self.index_wid.set_widget_state(index, allow_callback=False)
             else:
                 self.index_wid.set_widget_state(
-                    index, loop_enabled=self.loop_checkbox.value,
+                    index, loop_enabled=self.loop_toggle.value,
                     text_editable=True, allow_callback=False)
             self.selected_values = index['index']
             self.min = index['min']

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -4494,7 +4494,7 @@ class PlotOptionsWidget(MenpoWidget):
         * ``marker_edge_width = [2.] * self.n_curves``
         * ``zoom = [1., 1.]``
 
-        where ``colours = sample_colours_from_colourmap(self.n_curves, 'jet')``.
+        where ``colours = sample_colours_from_colourmap(self.n_curves, 'Paired')``.
         """
         render_lines = [True] * self.n_curves
         line_style = ['-'] * self.n_curves
@@ -4507,9 +4507,9 @@ class PlotOptionsWidget(MenpoWidget):
         line_colour = ['red']
         marker_edge_colour = ['red']
         if self.n_curves > 1:
-            line_colour = sample_colours_from_colourmap(self.n_curves, 'jet')
+            line_colour = sample_colours_from_colourmap(self.n_curves, 'Paired')
             marker_edge_colour = sample_colours_from_colourmap(
-                self.n_curves, 'jet')
+                self.n_curves, 'Paired')
         return {'title': '', 'x_label': '', 'y_label': '', 'render_legend': True,
                 'legend_entries': self.legend_entries,
                 'legend_title': '', 'legend_font_name': 'sans-serif',

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -4511,6 +4511,7 @@ class PlotOptionsWidget(MenpoWidget):
             marker_edge_colour = sample_colours_from_colourmap(
                 self.n_curves, 'jet')
         return {'title': '', 'x_label': '', 'y_label': '', 'render_legend': True,
+                'legend_entries': self.legend_entries,
                 'legend_title': '', 'legend_font_name': 'sans-serif',
                 'legend_font_style': 'normal', 'legend_font_size': 10,
                 'legend_font_weight': 'normal', 'legend_marker_scale': 1.,
@@ -4521,8 +4522,8 @@ class PlotOptionsWidget(MenpoWidget):
                 'legend_shadow': False, 'legend_rounded_corners': False,
                 'render_axes': True, 'axes_font_name': 'sans-serif',
                 'axes_font_size': 10, 'axes_font_style': 'normal',
-                'axes_font_weight': 'normal', 'axes_x_limits': None,
-                'axes_y_limits': None, 'axes_x_ticks': None,
+                'axes_font_weight': 'normal', 'axes_x_limits': 0.,
+                'axes_y_limits': 0., 'axes_x_ticks': None,
                 'axes_y_ticks': None, 'render_grid': True,
                 'grid_line_style': '--', 'grid_line_width': 0.5,
                 'render_lines': render_lines, 'line_width': line_width,

--- a/menpowidgets/tools.py
+++ b/menpowidgets/tools.py
@@ -2857,20 +2857,22 @@ class AxesLimitsWidget(MenpoWidget):
             range_visible = True
         self.axes_x_limits_toggles = ipywidgets.ToggleButtons(
             description='X limits:', value=toggles_initial_value,
-            options=['auto', 'percentage', 'range'], margin='0.2cm')
+            options=['auto', 'percentage', 'range'], margin='0.1cm')
         self.axes_x_limits_percentage = ListWidget(
             percentage_initial_value, mode='float', description='',
             render_function=None, example_visible=False)
+        self.axes_x_limits_percentage.margin = '0.1cm'
         self.axes_x_limits_percentage.visible = percentage_visible
         self.axes_x_limits_range = ListWidget(
             range_initial_value, mode='float', description='',
             render_function=None, example_visible=False)
+        self.axes_x_limits_range.margin = '0.1cm'
         self.axes_x_limits_range.visible = range_visible
-        self.axes_x_limits_options_box = ipywidgets.VBox(
+        self.axes_x_limits_options_box = ipywidgets.HBox(
             children=[self.axes_x_limits_percentage, self.axes_x_limits_range])
         self.axes_x_limits_box = ipywidgets.HBox(
             children=[self.axes_x_limits_toggles,
-                      self.axes_x_limits_options_box], align='center')
+                      self.axes_x_limits_options_box], align='start')
 
         # y limits
         if axes_y_limits is None:
@@ -2893,20 +2895,22 @@ class AxesLimitsWidget(MenpoWidget):
             range_visible = True
         self.axes_y_limits_toggles = ipywidgets.ToggleButtons(
             description='Y limits:', value=toggles_initial_value,
-            options=['auto', 'percentage', 'range'], margin='0.2cm')
+            options=['auto', 'percentage', 'range'], margin='0.1cm')
         self.axes_y_limits_percentage = ListWidget(
             percentage_initial_value, mode='float', description='',
             render_function=None, example_visible=False)
+        self.axes_y_limits_percentage.margin = '0.1cm'
         self.axes_y_limits_percentage.visible = percentage_visible
         self.axes_y_limits_range = ListWidget(
             range_initial_value, mode='float', description='',
             render_function=None, example_visible=False)
+        self.axes_y_limits_range.margin = '0.1cm'
         self.axes_y_limits_range.visible = range_visible
-        self.axes_y_limits_options_box = ipywidgets.VBox(
+        self.axes_y_limits_options_box = ipywidgets.HBox(
             children=[self.axes_y_limits_percentage, self.axes_y_limits_range])
         self.axes_y_limits_box = ipywidgets.HBox(
             children=[self.axes_y_limits_toggles,
-                      self.axes_y_limits_options_box], align='center')
+                      self.axes_y_limits_options_box], align='start')
 
         # Create final widget
         children = [self.axes_x_limits_box, self.axes_y_limits_box]
@@ -2948,13 +2952,15 @@ class AxesLimitsWidget(MenpoWidget):
             elif self.axes_x_limits_toggles.value == 'percentage':
                 x_val = self.axes_x_limits_percentage.selected_values[0]
             else:
-                x_val = self.axes_x_limits_range.selected_values
+                x_val = [self.axes_x_limits_range.selected_values[0],
+                         self.axes_x_limits_range.selected_values[1]]
             if self.axes_y_limits_toggles.value == 'auto':
                 y_val = None
             elif self.axes_y_limits_toggles.value == 'percentage':
                 y_val = self.axes_y_limits_percentage.selected_values[0]
             else:
-                y_val = self.axes_y_limits_range.selected_values
+                y_val = [self.axes_y_limits_range.selected_values[0],
+                         self.axes_y_limits_range.selected_values[1]]
             self.selected_values = {'x': x_val, 'y': y_val}
         self.axes_x_limits_toggles.observe(save_options, names='value',
                                            type='change')
@@ -3033,22 +3039,22 @@ class AxesLimitsWidget(MenpoWidget):
         self.axes_y_limits_toggles.button_style = toggles_style
         self.axes_x_limits_percentage.style(
             box_style=box_style, border_visible=False, padding=0,
-            margin=0, text_box_style=box_style, text_box_width=None,
+            margin='0.1cm', text_box_style=box_style, text_box_width=None,
             font_family=font_family, font_size=font_size,
             font_style=font_style, font_weight=font_weight)
         self.axes_x_limits_range.style(
             box_style=box_style, border_visible=False, padding=0,
-            margin=0, text_box_style=box_style, text_box_width=None,
+            margin='0.1cm', text_box_style=box_style, text_box_width=None,
             font_family=font_family, font_size=font_size,
             font_style=font_style, font_weight=font_weight)
         self.axes_y_limits_percentage.style(
             box_style=box_style, border_visible=False, padding=0,
-            margin=0, text_box_style=box_style, text_box_width=None,
+            margin='0.1cm', text_box_style=box_style, text_box_width=None,
             font_family=font_family, font_size=font_size,
             font_style=font_style, font_weight=font_weight)
         self.axes_y_limits_range.style(
             box_style=box_style, border_visible=False, padding=0,
-            margin=0, text_box_style=box_style, text_box_width=None,
+            margin='0.1cm', text_box_style=box_style, text_box_width=None,
             font_family=font_family, font_size=font_size,
             font_style=font_style, font_weight=font_weight)
 

--- a/menpowidgets/tools.py
+++ b/menpowidgets/tools.py
@@ -1052,7 +1052,8 @@ class ColourSelectionWidget(MenpoWidget):
         if not multiple:
             colour_description = description
         self.colour_widget = ipywidgets.ColorPicker(
-            value=default_colour, description=colour_description, width='3cm')
+            value=default_colour, description=colour_description, width='3cm',
+            tooltip='Select colour')
 
         # Create final widget
         children = [self.labels_box, self.colour_widget]
@@ -1360,11 +1361,13 @@ class ZoomOneScaleWidget(MenpoWidget):
         # Create children
         self.title = ipywidgets.Latex(value=description, padding=6, margin=6)
         m_icon, m_description = parse_font_awesome_icon(minus_description)
-        self.button_minus = ipywidgets.Button(description=m_description,
-                                              icon=m_icon, width='1cm')
+        self.button_minus = ipywidgets.Button(
+            description=m_description, icon=m_icon, width='1cm',
+            tooltip='Zoom Out')
         p_icon, p_description = parse_font_awesome_icon(plus_description)
-        self.button_plus = ipywidgets.Button(description=p_description,
-                                             icon=p_icon, width='1cm')
+        self.button_plus = ipywidgets.Button(
+            description=p_description, icon=p_icon, width='1cm',
+            tooltip='Zoom In')
         self.zoom_slider = ipywidgets.FloatSlider(
             value=zoom_options['zoom'], min=zoom_options['min'],
             max=zoom_options['max'], step=zoom_options['step'], readout=False,
@@ -1571,15 +1574,19 @@ class ZoomTwoScalesWidget(MenpoWidget):
         self.x_title = ipywidgets.Latex(value='X', padding=6, margin=6)
         self.y_title = ipywidgets.Latex(value='Y', padding=6, margin=6)
         m_icon, m_description = parse_font_awesome_icon(minus_description)
-        self.x_button_minus = ipywidgets.Button(description=m_description,
-                                                icon=m_icon, width='1cm')
-        self.y_button_minus = ipywidgets.Button(description=m_description,
-                                                icon=m_icon, width='1cm')
+        self.x_button_minus = ipywidgets.Button(
+            description=m_description, icon=m_icon, width='1cm',
+            tooltip='Zoom Out')
+        self.y_button_minus = ipywidgets.Button(
+            description=m_description, icon=m_icon, width='1cm',
+            tooltip='Zoom Out')
         p_icon, p_description = parse_font_awesome_icon(plus_description)
-        self.x_button_plus = ipywidgets.Button(description=p_description,
-                                               icon=p_icon, width='1cm')
-        self.y_button_plus = ipywidgets.Button(description=p_description,
-                                               icon=p_icon, width='1cm')
+        self.x_button_plus = ipywidgets.Button(
+            description=p_description, icon=p_icon, width='1cm',
+            tooltip='Zoom In')
+        self.y_button_plus = ipywidgets.Button(
+            description=p_description, icon=p_icon, width='1cm',
+            tooltip='Zoom In')
         self.x_zoom_slider = ipywidgets.FloatSlider(
             value=zoom_options['zoom'][0], min=zoom_options['min'],
             max=zoom_options['max'], readout=False, width='6cm',
@@ -1609,7 +1616,7 @@ class ZoomTwoScalesWidget(MenpoWidget):
             self.lock_link.unlink()
         self.lock_aspect_button = ipywidgets.ToggleButton(
             value=zoom_options['lock_aspect_ratio'], description='',
-            icon=lock_icon)
+            icon=lock_icon, tooltip='Keep aspect ratio')
         self.options_box = ipywidgets.HBox(
             children=[self.lock_aspect_button, self.x_y_box], align='center')
 


### PR DESCRIPTION
This PR changes the behaviour of `IterativeResultOptionsWidget` (and thus `visualize_fitting_result`) with respect to the changes introduced in https://github.com/menpo/menpofit/pull/86 about the reconstructed initial shapes of parametric fittings. The main change is that the number of iteration shapes is not controlled by `fitting_result.n_iters`, since this does not count the reconstruction steps; it is controlled by `len(fitting_result.shapes)`.

The PR also changes the default colours of plotting curves. Until know we were sampling from the `jet` colourmap; now we sample from `Paired`.
