### PR TITLE
Add an optional additional argument for visualize_{} functions.

### DIFF
--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -650,7 +650,7 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
 
 
 def visualize_images(images, figure_size=(10, 8), style='coloured',
-                     browser_style='buttons', custom_function=None):
+                     browser_style='buttons', custom_info_callback=None):
     r"""
     Widget that allows browsing through a `list` of `menpo.image.Image` (or
     subclass) objects.
@@ -673,9 +673,10 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
     browser_style : ``{'buttons', 'slider'}``, optional
         It defines whether the selector of the objects will have the form of
         plus/minus buttons or a slider.
-    custom_function: `function` or ``None``, optional
+    custom_info_callback: `function` or ``None``, optional
         If not None, it should be a function that accepts an image and returns
-        the custom message to be printed per image.
+        a list of custom messages to be printed per image. Each custom message
+        will be printed in a separate line.
     """
     # Ensure that the code is being run inside a Jupyter kernel!
     from .utils import verify_ipython_and_kernel
@@ -766,17 +767,14 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
             figure_size=new_figure_size, **options)
 
         # Update info
-        if custom_function is None:
-            update_info(images[im], image_is_masked, selected_group)
-        else:
-            update_info(images[im], image_is_masked, selected_group,
-                        custom_function(images[im]))
+        update_info(images[im], image_is_masked, selected_group,
+                    custom_info_callback)
 
         # Save the current figure id
         save_figure_wid.renderer = renderer
 
     # Define function that updates the info text
-    def update_info(img, image_is_masked, group, custom_str=None):
+    def update_info(img, image_is_masked, group, custom_info_callback):
         # Prepare masked (or non-masked) string
         masked_str = 'Masked Image' if image_is_masked else 'Image'
         # Get image path, if available
@@ -800,8 +798,9 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
             text_per_line.append("> {} landmark points".format(
                 img.landmarks[group].lms.n_points))
             n_lines += 1
-        if custom_str is not None:
-            text_per_line.append('> custom message: {}'.format(custom_str))
+        if custom_info_callback is not None:
+            for msg in custom_info_callback(img):
+                text_per_line.append('> {}'.format(msg))
         info_wid.set_widget_state(text_per_line=text_per_line)
 
     # Create widgets

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -650,7 +650,7 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
 
 
 def visualize_images(images, figure_size=(10, 8), style='coloured',
-                     browser_style='buttons', messages=''):
+                     browser_style='buttons', custom_function=None):
     r"""
     Widget that allows browsing through a `list` of `menpo.image.Image` (or
     subclass) objects.
@@ -673,9 +673,9 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
     browser_style : ``{'buttons', 'slider'}``, optional
         It defines whether the selector of the objects will have the form of
         plus/minus buttons or a slider.
-    messages: `list` with the same length as the `images`, optional
-        The list can be some additional message to print with each image,
-        along with the rest of the info.       
+    custom_function: `function` or ``None``, optional
+        If not None, it should be a function that accepts an image and returns
+        the custom message to be printed per image.
     """
     # Ensure that the code is being run inside a Jupyter kernel!
     from .utils import verify_ipython_and_kernel
@@ -688,14 +688,6 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
 
     # Get the number of images
     n_images = len(images)
-  
-    # ensure the messages are list and that they are of the 
-    # same length as images (if provided).
-    if not messages == '':
-        if not isinstance(messages, list):
-            raise ValueError('Messages should be of instance list if provided.')
-        if len(messages) != len(images):
-            raise ValueError('Messages should have the same length as the images.')
 
     # Define the styling options
     if style == 'coloured':
@@ -774,16 +766,17 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
             figure_size=new_figure_size, **options)
 
         # Update info
-        if messages != '':
-            update_info(images[im], image_is_masked, selected_group, messages[im])
-        else:
+        if custom_function is None:
             update_info(images[im], image_is_masked, selected_group)
+        else:
+            update_info(images[im], image_is_masked, selected_group,
+                        custom_function(images[im]))
 
         # Save the current figure id
         save_figure_wid.renderer = renderer
 
     # Define function that updates the info text
-    def update_info(img, image_is_masked, group, msg=''):
+    def update_info(img, image_is_masked, group, custom_str=None):
         # Prepare masked (or non-masked) string
         masked_str = 'Masked Image' if image_is_masked else 'Image'
         # Get image path, if available
@@ -807,8 +800,8 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
             text_per_line.append("> {} landmark points".format(
                 img.landmarks[group].lms.n_points))
             n_lines += 1
-        if msg != '':
-            text_per_line.append('> msg: {}'.format(msg))
+        if custom_str is not None:
+            text_per_line.append('> custom message: {}'.format(custom_str))
         info_wid.set_widget_state(text_per_line=text_per_line)
 
     # Create widgets

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -586,7 +586,6 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
                 "> Range: {0:.1f}W, {1:.1f}H".format(rang[0], rang[1]),
                 "> Centre of mass: ({0:.1f}, {1:.1f})".format(cm[0], cm[1]),
                 "> Norm: {0:.2f}".format(landmarks[group][None].norm())]
-            n_lines = 5
             if custom_info_callback is not None:
                 # iterate over the list of messages returned by the callback
                 # function and append them in the text_per_line.
@@ -594,7 +593,6 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
                     text_per_line.append('> {}'.format(msg))
         else:
             text_per_line = ["No landmarks available."]
-            n_lines = 1
 
         info_wid.set_widget_state(text_per_line=text_per_line)
 
@@ -814,19 +812,15 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
                 masked_str, img._str_shape(), img.n_channels,
                 's' * (img.n_channels > 1)),
             "> Path: '{}'".format(path_str)]
-        n_lines = 2
         if image_is_masked:
             text_per_line.append(
                 "> {} masked pixels (attached mask {:.1%} true)".format(
                     img.n_true_pixels(), img.mask.proportion_true()))
-            n_lines += 1
         text_per_line.append("> min={:.3f}, max={:.3f}".format(
             img.pixels.min(), img.pixels.max()))
-        n_lines += 1
         if img.has_landmarks:
             text_per_line.append("> {} landmark points".format(
                 img.landmarks[group].lms.n_points))
-            n_lines += 1
         if custom_info_callback is not None:
             # iterate over the list of messages returned by the callback
             # function and append them in the text_per_line.

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -40,7 +40,7 @@ def menpowidgets_src_dir_path():
 
 
 def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',
-                          browser_style='buttons'):
+                          browser_style='buttons', custom_info_callback=None):
     r"""
     Widget that allows browsing through a `list` of `menpo.shape.PointCloud`,
     `menpo.shape.PointUndirectedGraph`, `menpo.shape.PointDirectedGraph`,
@@ -65,6 +65,10 @@ def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',
     browser_style : ``{'buttons', 'slider'}``, optional
         It defines whether the selector of the objects will have the form of
         plus/minus buttons or a slider.
+    custom_info_callback: `function` or ``None``, optional
+        If not None, it should be a function that accepts a pointcloud
+        and returns a list of custom messages to be printed per
+        pointcloud. Each custom message will be printed in a separate line.
     """
     # Ensure that the code is being run inside a Jupyter kernel!
     from .utils import verify_ipython_and_kernel
@@ -139,13 +143,13 @@ def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',
         plt.show()
 
         # Update info text widget
-        update_info(pointclouds[im])
+        update_info(pointclouds[im], custom_info_callback=custom_info_callback)
 
         # Save the current figure id
         save_figure_wid.renderer = renderer
 
     # Define function that updates the info text
-    def update_info(pointcloud):
+    def update_info(pointcloud, custom_info_callback=None):
         min_b, max_b = pointcloud.bounds()
         rang = pointcloud.range()
         cm = pointcloud.centre()
@@ -156,6 +160,11 @@ def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',
             "> Range: {0:.1f}W, {1:.1f}H".format(rang[0], rang[1]),
             "> Centre of mass: ({0:.1f}, {1:.1f})".format(cm[0], cm[1]),
             "> Norm: {0:.2f}".format(pointcloud.norm())]
+        if custom_info_callback is not None:
+            # iterate over the list of messages returned by the callback
+            # function and append them in the text_per_line.
+            for msg in custom_info_callback(pointcloud):
+                text_per_line.append('> {}'.format(msg))
         info_wid.set_widget_state(text_per_line=text_per_line)
 
     # Create widgets
@@ -217,8 +226,8 @@ def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',
     render_function({})
 
 
-def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8),
-                             style='coloured', browser_style='buttons'):
+def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8), style='coloured',
+                             browser_style='buttons', custom_info_callback=None):
     r"""
     Widget that allows browsing through a `list` of
     `menpo.landmark.LandmarkGroup` (or subclass) objects.
@@ -240,6 +249,10 @@ def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8),
     browser_style : ``{'buttons', 'slider'}``, optional
         It defines whether the selector of the objects will have the form of
         plus/minus buttons or a slider.
+    custom_info_callback: `function` or ``None``, optional
+        If not None, it should be a function that accepts a landmark group
+        and returns a list of custom messages to be printed per landmark
+        group. Each custom message will be printed in a separate line.
     """
     # Ensure that the code is being run inside a Jupyter kernel!
     from .utils import verify_ipython_and_kernel
@@ -335,10 +348,10 @@ def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8),
             ipydisplay.clear_output()
 
         # update info text widget
-        update_info(landmarkgroups[im])
+        update_info(landmarkgroups[im], custom_info_callback=custom_info_callback)
 
     # Define function that updates the info text
-    def update_info(landmarkgroup):
+    def update_info(landmarkgroup, custom_info_callback=None):
         min_b, max_b = landmarkgroup.lms.bounds()
         rang = landmarkgroup.lms.range()
         cm = landmarkgroup.lms.centre()
@@ -349,6 +362,11 @@ def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8),
             "> Range: {0:.1f}W, {1:.1f}H".format(rang[0], rang[1]),
             "> Centre of mass: ({0:.1f}, {1:.1f})".format(cm[0], cm[1]),
             "> Norm: {0:.2f}".format(landmarkgroup.lms.norm())]
+        if custom_info_callback is not None:
+            # iterate over the list of messages returned by the callback
+            # function and append them in the text_per_line.
+            for msg in custom_info_callback(landmarkgroup):
+                text_per_line.append('> {}'.format(msg))
         info_wid.set_widget_state(text_per_line=text_per_line)
 
     # Create widgets
@@ -430,7 +448,7 @@ def visualize_landmarkgroups(landmarkgroups, figure_size=(10, 8),
 
 
 def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
-                        browser_style='buttons'):
+                        browser_style='buttons', custom_info_callback=None):
     r"""
     Widget that allows browsing through a `list` of
     `menpo.landmark.LandmarkManager` (or subclass) objects.
@@ -452,6 +470,10 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
     browser_style : ``{'buttons', 'slider'}``, optional
         It defines whether the selector of the objects will have the form of
         plus/minus buttons or a slider.
+    custom_info_callback: `function` or ``None``, optional
+        If not None, it should be a function that accepts a landmark group and returns
+        a list of custom messages to be printed per landmark group. Each custom message
+        will be printed in a separate line.
     """
     # Ensure that the code is being run inside a Jupyter kernel!
     from .utils import verify_ipython_and_kernel
@@ -548,10 +570,11 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
             ipydisplay.clear_output()
 
         # update info text widget
-        update_info(landmarks[im], selected_group)
+        update_info(landmarks[im], selected_group,
+                    custom_info_callback=custom_info_callback)
 
     # Define function that updates the info text
-    def update_info(landmarks, group):
+    def update_info(landmarks, group, custom_info_callback=None):
         if group is not None:
             min_b, max_b = landmarks[group][None].bounds()
             rang = landmarks[group][None].range()
@@ -564,9 +587,15 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
                 "> Centre of mass: ({0:.1f}, {1:.1f})".format(cm[0], cm[1]),
                 "> Norm: {0:.2f}".format(landmarks[group][None].norm())]
             n_lines = 5
+            if custom_info_callback is not None:
+                # iterate over the list of messages returned by the callback
+                # function and append them in the text_per_line.
+                for msg in custom_info_callback(landmarks[group][None]):
+                    text_per_line.append('> {}'.format(msg))
         else:
             text_per_line = ["No landmarks available."]
             n_lines = 1
+
         info_wid.set_widget_state(text_per_line=text_per_line)
 
     # Create widgets
@@ -768,13 +797,13 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
 
         # Update info
         update_info(images[im], image_is_masked, selected_group,
-                    custom_info_callback)
+                    custom_info_callback=custom_info_callback)
 
         # Save the current figure id
         save_figure_wid.renderer = renderer
 
     # Define function that updates the info text
-    def update_info(img, image_is_masked, group, custom_info_callback):
+    def update_info(img, image_is_masked, group, custom_info_callback=None):
         # Prepare masked (or non-masked) string
         masked_str = 'Masked Image' if image_is_masked else 'Image'
         # Get image path, if available
@@ -799,6 +828,8 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
                 img.landmarks[group].lms.n_points))
             n_lines += 1
         if custom_info_callback is not None:
+            # iterate over the list of messages returned by the callback
+            # function and append them in the text_per_line.
             for msg in custom_info_callback(img):
                 text_per_line.append('> {}'.format(msg))
         info_wid.set_widget_state(text_per_line=text_per_line)
@@ -883,8 +914,8 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
     render_function({})
 
 
-def visualize_patches(patches, patch_centers, figure_size=(10, 8),
-                      style='coloured', browser_style='buttons'):
+def visualize_patches(patches, patch_centers, figure_size=(10, 8), style='coloured',
+                      browser_style='buttons', custom_info_callback=None):
     r"""
     Widget that allows browsing through a `list` of patch-based images.
 
@@ -921,6 +952,10 @@ def visualize_patches(patches, patch_centers, figure_size=(10, 8),
     browser_style : ``{'buttons', 'slider'}``, optional
         It defines whether the selector of the objects will have the form of
         plus/minus buttons or a slider.
+    custom_info_callback: `function` or ``None``, optional
+        If not None, it should be a function that accepts an image and returns
+        a list of custom messages to be printed per image. Each custom message
+        will be printed in a separate line.
     """
     # Ensure that the code is being run inside a Jupyter kernel!
     from .utils import verify_ipython_and_kernel
@@ -1007,13 +1042,13 @@ def visualize_patches(patches, patch_centers, figure_size=(10, 8),
             **options)
 
         # update info text widget
-        update_info(patches[im])
+        update_info(patches[im], custom_info_callback=custom_info_callback)
 
         # Save the current figure id
         save_figure_wid.renderer = renderer
 
     # Define function that updates the info text
-    def update_info(ptchs):
+    def update_info(ptchs, custom_info_callback=None):
         text_per_line = [
             "> Patch-Based Image with {} patche{} and {} offset{}.".format(
                 ptchs.shape[0], 's' * (ptchs.shape[0] > 1), ptchs.shape[1],
@@ -1022,6 +1057,11 @@ def visualize_patches(patches, patch_centers, figure_size=(10, 8),
                 ptchs.shape[3], ptchs.shape[4], ptchs.shape[2],
                 's' * (ptchs.shape[2] > 1)),
             "> min={:.3f}, max={:.3f}".format(ptchs.min(), ptchs.max())]
+        if custom_info_callback is not None:
+            # iterate over the list of messages returned by the callback
+            # function and append them in the text_per_line.
+            for msg in custom_info_callback(ptchs):
+                text_per_line.append('> {}'.format(msg))
         info_wid.set_widget_state(text_per_line=text_per_line)
 
     # Create widgets

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -650,7 +650,7 @@ def visualize_landmarks(landmarks, figure_size=(10, 8), style='coloured',
 
 
 def visualize_images(images, figure_size=(10, 8), style='coloured',
-                     browser_style='buttons'):
+                     browser_style='buttons', messages=''):
     r"""
     Widget that allows browsing through a `list` of `menpo.image.Image` (or
     subclass) objects.
@@ -673,6 +673,9 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
     browser_style : ``{'buttons', 'slider'}``, optional
         It defines whether the selector of the objects will have the form of
         plus/minus buttons or a slider.
+    messages: `list` with the same length as the `images`, optional
+        The list can be some additional message to print with each image,
+        along with the rest of the info.       
     """
     # Ensure that the code is being run inside a Jupyter kernel!
     from .utils import verify_ipython_and_kernel
@@ -685,6 +688,14 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
 
     # Get the number of images
     n_images = len(images)
+  
+    # ensure the messages are list and that they are of the 
+    # same length as images (if provided).
+    if not messages == '':
+        if not isinstance(messages, list):
+            raise ValueError('Messages should be of instance list if provided.')
+        if len(messages) != len(images):
+            raise ValueError('Messages should have the same length as the images.')
 
     # Define the styling options
     if style == 'coloured':
@@ -763,13 +774,16 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
             figure_size=new_figure_size, **options)
 
         # Update info
-        update_info(images[im], image_is_masked, selected_group)
+        if messages != '':
+            update_info(images[im], image_is_masked, selected_group, messages[im])
+        else:
+            update_info(images[im], image_is_masked, selected_group)
 
         # Save the current figure id
         save_figure_wid.renderer = renderer
 
     # Define function that updates the info text
-    def update_info(img, image_is_masked, group):
+    def update_info(img, image_is_masked, group, msg=''):
         # Prepare masked (or non-masked) string
         masked_str = 'Masked Image' if image_is_masked else 'Image'
         # Get image path, if available
@@ -793,6 +807,8 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
             text_per_line.append("> {} landmark points".format(
                 img.landmarks[group].lms.n_points))
             n_lines += 1
+        if msg != '':
+            text_per_line.append('> msg: {}'.format(msg))
         info_wid.set_widget_state(text_per_line=text_per_line)
 
     # Create widgets

--- a/menpowidgets/menpofit/base.py
+++ b/menpowidgets/menpofit/base.py
@@ -1946,8 +1946,8 @@ def plot_ced(errors, legend_entries=None, error_range=None,
         return wid
 
 
-def visualize_fitting_result(fitting_results, figure_size=(10, 8),
-                             style='coloured', browser_style='buttons'):
+def visualize_fitting_result(fitting_results, figure_size=(10, 8), style='coloured',
+                             browser_style='buttons', custom_info_callback=None):
     r"""
     Widget that allows browsing through a `list` of fitting results.
 
@@ -1965,6 +1965,10 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
     browser_style : ``{'buttons', 'slider'}``, optional
         It defines whether the selector of the objects will have the form of
         plus/minus buttons or a slider.
+    custom_info_callback: `function` or ``None``, optional
+        If not None, it should be a function that accepts a fitting result
+        and returns a list of custom messages to be printed per result.
+        Each custom message will be printed in a separate line.
     """
     # Ensure that the code is being run inside a Jupyter kernel!
     from menpowidgets.utils import verify_ipython_and_kernel
@@ -2182,13 +2186,13 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
         plt.show()
 
         # update info text widget
-        update_info({})
+        update_info({}, custom_info_callback=custom_info_callback)
 
         # Save the current figure id
         save_figure_wid.renderer = renderer
 
     # Define function that updates info text
-    def update_info(change):
+    def update_info(change, custom_info_callback=None):
         # Get selected object
         im = image_number_wid.selected_values if n_fitting_results > 1 else 0
         fr = fitting_results[im]
@@ -2224,6 +2228,11 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
             text_per_line.append(' > No iterations.')
         if hasattr(fr, 'n_scales'):
             text_per_line.append(' > {} scales.'.format(fr.n_scales))
+        if custom_info_callback is not None:
+            # iterate over the list of messages returned by the callback
+            # function and append them in the text_per_line.
+            for msg in custom_info_callback(fr):
+                text_per_line.append('> {}'.format(msg))
         info_wid.set_widget_state(text_per_line=text_per_line)
 
     # Create renderer widget


### PR DESCRIPTION
This optional argument prints a message (element) for each image.

Currently, there is no way to print some additional info in the info box. 
This can be useful if you want to print additional info along with the images, e.g. the angle of the image, the fitting error of the saved landmarks, any non-included message. 

New code that works for me (apart from the old options that work fine):

```
import menpo.io as mio
c = mio.import_builtin_asset
ims = [c.lenna_png(), c.takeo_ppm(), c.einstein_jpg()]
try:
    %matplotlib inline
    from menpowidgets import visualize_images
except NameError:
    pass

visualize_images(ims, messages=list(range(3)))
```
