### PR TITLE
Bugfix: visualize_fitting_result for Result object

### DIFF
--- a/menpowidgets/menpofit/base.py
+++ b/menpowidgets/menpofit/base.py
@@ -2314,12 +2314,13 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8), style='colour
     n_shapes = None
     if fitting_results[0].is_iterative:
         n_shapes = len(fitting_results[0].shapes)
+    has_costs = (fitting_results[0].is_iterative and
+                 fitting_results[0].costs is not None)
     fitting_result_wid = IterativeResultOptionsWidget(
         has_gt_shape=fitting_results[0].gt_shape is not None,
         has_initial_shape=fitting_results[0].initial_shape is not None,
         has_image=fitting_results[0].image is not None,
-        n_shapes=n_shapes, has_costs=fitting_results[0].costs is not None,
-        render_function=render_function,
+        n_shapes=n_shapes, has_costs=has_costs, render_function=render_function,
         tab_update_function=update_renderer_options,
         displacements_function=plot_displacements_function,
         errors_function=plot_errors_function,
@@ -2340,13 +2341,13 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8), style='colour
             n_shapes = None
             if fitting_results[im].is_iterative:
                 n_shapes = len(fitting_results[im].shapes)
+            has_costs = (fitting_results[im].is_iterative and
+                         fitting_results[im].costs is not None)
             fitting_result_wid.set_widget_state(
                 has_gt_shape=fitting_results[im].gt_shape is not None,
                 has_initial_shape=fitting_results[im].initial_shape is not None,
                 has_image=fitting_results[im].image is not None,
-                n_shapes=n_shapes,
-                has_costs=fitting_results[im].costs is not None,
-                allow_callback=False)
+                n_shapes=n_shapes, has_costs=has_costs, allow_callback=False)
 
             # Update renderer options
             update_renderer_options({})

--- a/menpowidgets/menpofit/options.py
+++ b/menpowidgets/menpofit/options.py
@@ -534,12 +534,12 @@ class IterativeResultOptionsWidget(MenpoWidget):
                                      type='change')
         self.iterations_mode.observe(self._index_visibility, names='value',
                                      type='change')
-        index = {'min': 0, 'max': n_shapes - 1, 'step': 1, 'index': 0}
+        index = {'min': 0, 'max': 1, 'step': 1, 'index': 0}
         self.index_animation = AnimationOptionsWidget(
                 index, description='', index_style='slider',
                 loop_enabled=False, interval=0.)
-        slice_options = {'command': 'range({})'.format(n_shapes),
-                         'length': n_shapes}
+        slice_options = {'command': 'range({})'.format(1),
+                         'length': 1}
         self.index_slicing = SlicingCommandWidget(
                 slice_options, description='', example_visible=True,
                 continuous_update=False, orientation='vertical')


### PR DESCRIPTION
This fixes a bug when trying to visualize a `Result` object using `visualize_fitting_result`. The problem was that a `Result` object has no `costs` or `shapes` attributes which are required by `IterativeResultOptionsWidget`. This bug is important for `DlibWrapper`, which returns a `Result` instance after fitting.
