### PR TITLE
Webcam widget

### DIFF
--- a/docs/source/menpowidgets/base/index.rst
+++ b/docs/source/menpowidgets/base/index.rst
@@ -44,6 +44,7 @@ Various
 .. toctree::
     :maxdepth: 1
 
+    webcam_widget
     features_selection
     plot_graph
     save_matplotlib_figure

--- a/docs/source/menpowidgets/base/webcam_widget.rst
+++ b/docs/source/menpowidgets/base/webcam_widget.rst
@@ -1,0 +1,7 @@
+.. _menpowidgets-base-webcam_widget:
+
+.. currentmodule:: menpowidgets.base
+
+webcam_widget
+=============
+.. autofunction:: webcam_widget

--- a/docs/source/menpowidgets/options/CameraSnapshotWidget.rst
+++ b/docs/source/menpowidgets/options/CameraSnapshotWidget.rst
@@ -1,0 +1,10 @@
+.. _menpowidgets-options-CameraSnapshotWidget:
+
+.. currentmodule:: menpowidgets.options
+
+CameraSnapshotWidget
+====================
+.. autoclass:: CameraSnapshotWidget
+  :members: add_render_function, remove_render_function, replace_render_function, call_render_function, style, predefined_style, 
+            add_traits, close, has_trait, observe, trait_names, traits, unobserve, unobserve_all
+  :show-inheritance:

--- a/docs/source/menpowidgets/options/index.rst
+++ b/docs/source/menpowidgets/options/index.rst
@@ -13,6 +13,7 @@ and :ref:`api-menpofit-base-index`.
     :maxdepth: 1
 
     AnimationOptionsWidget
+    CameraSnapshotWidget
     ChannelOptionsWidget
     FeatureOptionsWidget
     LandmarkOptionsWidget

--- a/docs/source/menpowidgets/tools/CameraWidget.rst
+++ b/docs/source/menpowidgets/tools/CameraWidget.rst
@@ -1,0 +1,9 @@
+.. _menpowidgets-tools-CameraWidget:
+
+.. currentmodule:: menpowidgets.tools
+
+CameraWidget
+============
+.. autoclass:: CameraWidget
+  :members: add_traits, close, has_trait, observe, trait_names, traits, unobserve, unobserve_all
+  :show-inheritance:

--- a/docs/source/menpowidgets/tools/index.rst
+++ b/docs/source/menpowidgets/tools/index.rst
@@ -59,3 +59,12 @@ Features
     HOGOptionsWidget
     IGOOptionsWidget
     LBPOptionsWidget
+
+
+Webcam
+------
+
+.. toctree::
+    :maxdepth: 1
+    
+    CameraWidget

--- a/docs/xref_map.py
+++ b/docs/xref_map.py
@@ -1,6 +1,8 @@
 xref_map = {
 'AnimationOptionsWidget': ('class', 'menpowidgets.options.AnimationOptionsWidget'),
 'AxesOptionsWidget': ('class', 'menpowidgets.tools.AxesOptionsWidget'),
+'CameraSnapshotWidget': ('class', 'menpowidgets.options.CameraSnapshotWidget'),
+'CameraWidget': ('class', 'menpowidgets.tools.CameraWidget'),
 'ColourSelectionWidget': ('class', 'menpowidgets.tools.ColourSelectionWidget'),
 'DaisyOptionsWidget': ('class', 'menpowidgets.tools.DaisyOptionsWidget'),
 'DSIFTOptionsWidget': ('class', 'menpowidgets.tools.DSIFTOptionsWidget'),

--- a/menpowidgets/__init__.py
+++ b/menpowidgets/__init__.py
@@ -2,7 +2,7 @@ from .base import (visualize_pointclouds, visualize_landmarkgroups,
                    visualize_landmarks, visualize_images, visualize_patches,
                    plot_graph, save_matplotlib_figure, features_selection,
                    visualize_appearance_model, visualize_patch_appearance_model,
-                   visualize_shape_model)
+                   visualize_shape_model, webcam_widget)
 from .menpofit import *
 
 

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -13,7 +13,8 @@ from .options import (RendererOptionsWidget, TextPrintWidget,
                       SaveFigureOptionsWidget, AnimationOptionsWidget,
                       LandmarkOptionsWidget, ChannelOptionsWidget,
                       FeatureOptionsWidget, PlotOptionsWidget,
-                      PatchOptionsWidget, LinearModelParametersWidget)
+                      PatchOptionsWidget, LinearModelParametersWidget,
+                      CameraSnapshotWidget)
 from .style import format_box, map_styles_to_hex_colours
 from .tools import LogoWidget
 from .utils import (extract_group_labels_from_landmarks,
@@ -2244,3 +2245,50 @@ def visualize_patch_appearance_model(appearance_model, centers,
 
     # Trigger initial visualization
     render_function({})
+
+
+def webcam_widget(canvas_width=640, hd=True, n_preview_windows=5,
+                  style='coloured'):
+    r"""
+    Webcam widget for taking snapshots. The snapshots are dynamically previewed
+    in a FIFO stack of thumbnails.
+
+    Parameters
+    ----------
+    canvas_width : `int`, optional
+        The initial width of the rendered canvas. Note that this doesn't actually
+        change the webcam resolution. It simply rescales the rendered image, as
+        well as the size of the returned screenshots.
+    hd : `bool`, optional
+        If ``True``, then the webcam will be set to high definition (HD), i.e.
+        720 x 1280. Otherwise the default resolution will be used.
+    n_preview_windows : `int`, optional
+        The number of preview thumbnails that will be used as a FIFO stack to
+        show the captured screenshots. It must be at least 4.
+    style : ``{'coloured', 'minimal'}``, optional
+        If ``'coloured'``, then the style of the widget will be coloured. If
+        ``minimal``, then the style is simple using black and white colours.
+
+    Returns
+    -------
+    snapshots : `list` of `menpo.image.Image`
+        The list of captured images.
+    """
+    # Define the styling options
+    if style == 'coloured':
+        wid_style = 'danger'
+        preview_style = 'warning'
+    else:
+        wid_style = 'minimal'
+        preview_style = 'minimal'
+
+    # Create widgets
+    wid = CameraSnapshotWidget(
+        canvas_width=canvas_width, hd=hd, n_preview_windows=n_preview_windows,
+        preview_windows_margin=3, style=wid_style, preview_style=preview_style)
+
+    # Display widget
+    ipydisplay.display(wid)
+
+    # Return
+    return wid.selected_values

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -2274,6 +2274,10 @@ def webcam_widget(canvas_width=640, hd=True, n_preview_windows=5,
     snapshots : `list` of `menpo.image.Image`
         The list of captured images.
     """
+    # Ensure that the code is being run inside a Jupyter kernel!
+    from .utils import verify_ipython_and_kernel
+    verify_ipython_and_kernel()
+
     # Define the styling options
     if style == 'coloured':
         wid_style = 'danger'

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -4,7 +4,6 @@ from matplotlib import collections as mc
 import numpy as np
 
 import ipywidgets
-import traitlets
 import IPython.display as ipydisplay
 
 from menpo.image import MaskedImage, Image
@@ -38,52 +37,6 @@ def menpowidgets_src_dir_path():
     from pathlib import Path
     import os.path
     return Path(os.path.abspath(__file__)).parent
-
-
-class CameraWidget(ipywidgets.DOMWidget):
-    _view_name = traitlets.Unicode('CameraView').tag(sync=True)
-    imageurl = traitlets.Unicode('').tag(sync=True)
-    take_snapshot = traitlets.Bool(False).tag(sync=True)
-
-    def __init__(self, *args):
-        super(CameraWidget, self).__init__(*args)
-        self.observe(self._from_data_url, names='imageurl',
-                     type='change')
-        self.snapshots = []
-
-    @staticmethod
-    def _from_data_url(change):
-        from PIL import Image as PILImage
-        from io import BytesIO
-
-        self = change['owner']
-        data_uri = change['new']
-        data_uri = data_uri[len('data:image/png;base64,'):]
-        im = PILImage.open(BytesIO(data_uri.decode('base64')))
-
-        self.snapshots.append(Image.init_from_channels_at_back(
-            np.array(im)[..., :3]))
-
-
-def take_picture():
-    with open(str(menpowidgets_src_dir_path() / 'js' / 'webcam.js'), 'r') as f:
-        ipydisplay.display(ipydisplay.Javascript(data=f.read()))
-
-    wid = CameraWidget()
-    snapshot_but = ipywidgets.Button(description='Take Snapshot')
-    close_but = ipywidgets.Button(description='Close')
-
-    def take_snapshot(_):
-        wid.take_snapshot = not wid.take_snapshot
-    snapshot_but.on_click(take_snapshot)
-
-    def close(_):
-        wid.close()
-        snapshot_but.close()
-        close_but.close()
-    close_but.on_click(close)
-    ipydisplay.display(wid, close_but, snapshot_but)
-    return wid.snapshots
 
 
 def visualize_pointclouds(pointclouds, figure_size=(10, 8), style='coloured',

--- a/menpowidgets/js/webcam.js
+++ b/menpowidgets/js/webcam.js
@@ -1,0 +1,97 @@
+require(["nbextensions/widgets/widgets/js/widget",
+    "nbextensions/widgets/widgets/js/manager"], function(widget, manager) {
+    var CameraView = widget.DOMWidgetView.extend({
+        render: function() {
+            var that = this;
+            that.video  = $('<video>')[0];
+            that.canvas = $('<canvas>')[0];
+            that.width  = 640;
+            that.height = 480;
+            that.streaming = false;
+
+            // We append the HTML elements.
+            setTimeout(function() {
+                that.$el.append(that.video).
+                append(that.canvas);
+                that.canvas.style.display = 'none';
+            }, 200);
+
+            // We initialize the webcam.
+            navigator.getMedia = (navigator.getUserMedia       ||
+            navigator.webkitGetUserMedia ||
+            navigator.mozGetUserMedia    ||
+            navigator.msGetUserMedia);
+
+            navigator.getMedia({video: true, audio: false},
+                function(stream) {
+                    if (navigator.mozGetUserMedia) {
+                        that.video.mozSrcObject = stream;
+                    } else {
+                        var vendorURL = window.URL || window.webkitURL;
+                        that.video.src = vendorURL.createObjectURL(stream);
+                    }
+                    that.video.stream = stream;
+                    that.video.play();
+                },
+                function(err) {
+                    console.log("An error occured! " + err);
+                }
+            );
+
+            // We initialize the size of the canvas.
+            that.video.addEventListener('canplay', function(ev){
+                if (!that.streaming) {
+                    that.height = that.video.videoHeight / (that.video.videoWidth / that.width);
+                    that.video.setAttribute('width', that.width);
+                    that.video.setAttribute('height', that.height);
+                    that.canvas.setAttribute('width', that.width);
+                    that.canvas.setAttribute('height', that.height);
+
+                    that.streaming = true;
+                }
+            }, false);
+
+            // It takes a picture and sends it to the model.
+            function takepicture() {
+                that.canvas.width = that.width;
+                that.canvas.height = that.height;
+
+                // We take a screenshot from the webcam feed and
+                // we put the image in the first canvas.
+                that.canvas.getContext('2d').drawImage(that.video,
+                    0, 0,
+                    that.width, that.height);
+
+                // We export the canvas image to the model.
+                that.model.set('imageurl', that.canvas.toDataURL('image/png'));
+                that.touch();
+            }
+
+            function destroy() {
+                if (that.video) {
+                    that.video.stream.getVideoTracks()[0].stop();
+                    delete that.video.stream;
+                    that.video.remove();
+                    delete that.video;
+                }
+                if (that.canvas) {
+                    that.canvas.remove();
+                    delete that.canvas;
+                }
+            }
+
+            window.addEventListener('beforeunload', function(event) {
+                destroy();
+            });
+
+            that.model.on('change:take_snapshot', takepicture);
+
+            that.on("remove", destroy);
+            that.on("comm:dead", destroy);
+
+        }
+    });
+
+    // Register the view with the widget manager.
+    manager.WidgetManager.register_widget_view('CameraView', CameraView);
+});

--- a/menpowidgets/js/webcam.js
+++ b/menpowidgets/js/webcam.js
@@ -26,6 +26,8 @@ require(["nbextensions/widgets/widgets/js/widget", "nbextensions/widgets/widgets
             this.video.setAttribute('height', this.height);
             this.canvas.setAttribute('width', this.width);
             this.canvas.setAttribute('height', this.height);
+            this.model.set('canvas_height', this.height);
+            this.touch();
         },
         _wire_handlers: function() {
             var that = this;

--- a/menpowidgets/js/webcam.js
+++ b/menpowidgets/js/webcam.js
@@ -1,28 +1,33 @@
-require(["nbextensions/widgets/widgets/js/widget",
-    "nbextensions/widgets/widgets/js/manager"], function(widget, manager) {
+require(["nbextensions/widgets/widgets/js/widget", "nbextensions/widgets/widgets/js/manager"],
+    function(widget, manager) {
     var CameraView = widget.DOMWidgetView.extend({
         render: function() {
             var that = this;
             that.video  = $('<video>')[0];
             that.canvas = $('<canvas>')[0];
-            that.width  = 640;
+            that.width  = that.model.get('canvas_width');
             that.height = 480;
             that.streaming = false;
 
-            // We append the HTML elements.
+            // Set video constraints (resolution)
+            var video_constraints  = true;
+            if (that.model.get('hd')) {
+                video_constraints  = {mandatory: {minWidth: 1280, minHeight: 720}};
+            }
+
+            // Append the HTML elements
             setTimeout(function() {
-                that.$el.append(that.video).
-                append(that.canvas);
+                that.$el.append(that.video).append(that.canvas);
                 that.canvas.style.display = 'none';
             }, 200);
 
-            // We initialize the webcam.
-            navigator.getMedia = (navigator.getUserMedia       ||
+            // Initialize the webcam
+            navigator.getMedia = (navigator.getUserMedia ||
             navigator.webkitGetUserMedia ||
-            navigator.mozGetUserMedia    ||
+            navigator.mozGetUserMedia ||
             navigator.msGetUserMedia);
 
-            navigator.getMedia({video: true, audio: false},
+            navigator.getMedia({video: video_constraints, audio: false},
                 function(stream) {
                     if (navigator.mozGetUserMedia) {
                         that.video.mozSrcObject = stream;
@@ -35,38 +40,43 @@ require(["nbextensions/widgets/widgets/js/widget",
                 },
                 function(err) {
                     console.log("An error occured! " + err);
+                    that.model.set('error_occurred', true);
                 }
             );
 
-            // We initialize the size of the canvas.
+            // Resize video
+            function resize() {
+                that.width  = that.model.get('canvas_width');
+                that.height = that.video.videoHeight / (that.video.videoWidth / that.width);
+                that.video.setAttribute('width', that.width);
+                that.video.setAttribute('height', that.height);
+                that.canvas.setAttribute('width', that.width);
+                that.canvas.setAttribute('height', that.height);
+            }
+
+            // Initialize the size of the canvas
             that.video.addEventListener('canplay', function(ev){
                 if (!that.streaming) {
-                    that.height = that.video.videoHeight / (that.video.videoWidth / that.width);
-                    that.video.setAttribute('width', that.width);
-                    that.video.setAttribute('height', that.height);
-                    that.canvas.setAttribute('width', that.width);
-                    that.canvas.setAttribute('height', that.height);
-
+                    resize();
                     that.streaming = true;
                 }
             }, false);
 
-            // It takes a picture and sends it to the model.
+            // It takes a picture and sends it to the model
             function takepicture() {
                 that.canvas.width = that.width;
                 that.canvas.height = that.height;
 
-                // We take a screenshot from the webcam feed and
-                // we put the image in the first canvas.
-                that.canvas.getContext('2d').drawImage(that.video,
-                    0, 0,
+                // Take a screenshot from the webcam feed and put the image in the canvas
+                that.canvas.getContext('2d').drawImage(that.video, 0, 0,
                     that.width, that.height);
 
-                // We export the canvas image to the model.
+                // Export the canvas image to the model
                 that.model.set('imageurl', that.canvas.toDataURL('image/png'));
                 that.touch();
             }
 
+            // Destroy the webcam
             function destroy() {
                 if (that.video) {
                     that.video.stream.getVideoTracks()[0].stop();
@@ -80,18 +90,17 @@ require(["nbextensions/widgets/widgets/js/widget",
                 }
             }
 
+            // Add listeners
             window.addEventListener('beforeunload', function(event) {
                 destroy();
             });
-
             that.model.on('change:take_snapshot', takepicture);
-
             that.on("remove", destroy);
             that.on("comm:dead", destroy);
-
+            that.model.on('change:canvas_width', resize);
         }
     });
 
-    // Register the view with the widget manager.
+    // Register the view with the widget manager
     manager.WidgetManager.register_widget_view('CameraView', CameraView);
 });

--- a/menpowidgets/js/webcam.js
+++ b/menpowidgets/js/webcam.js
@@ -1,103 +1,119 @@
-require(["nbextensions/widgets/widgets/js/widget", "nbextensions/widgets/widgets/js/manager"],
-    function(widget, manager) {
+require(["nbextensions/widgets/widgets/js/widget", "nbextensions/widgets/widgets/js/manager"], function(widget, manager) {
     var CameraView = widget.DOMWidgetView.extend({
+        _take_snapshot: function() {
+            this.canvas.getContext('2d').drawImage(
+                this.video, 0, 0, this.width, this.height);
+
+            this.model.set('imageurl', this.canvas.toDataURL('image/png'));
+            this.touch();
+        },
+        _destroy_video: function() {
+            if (this.video) {
+                this.video.stream.getVideoTracks()[0].stop();
+                delete this.video.stream;
+                this.video.remove();
+                delete this.video;
+            }
+            if (this.canvas) {
+                this.canvas.remove();
+                delete this.canvas;
+            }
+        },
+        _resize_video: function() {
+            this.width  = this.model.get('canvas_width');
+            this.height = this.video.videoHeight / (this.video.videoWidth / this.width);
+            this.video.setAttribute('width', this.width);
+            this.video.setAttribute('height', this.height);
+            this.canvas.setAttribute('width', this.width);
+            this.canvas.setAttribute('height', this.height);
+        },
+        _wire_handlers: function() {
+            var that = this;
+            window.addEventListener('beforeunload', function(_) {
+                that._destroy_video();
+            });
+
+            that.on("remove", that._destroy_video, that);
+            that.on("comm:dead", that._destroy_video, that);
+            that.model.on('change:take_snapshot', that._take_snapshot, that);
+            that.model.on('change:canvas_width', that._resize_video, that);
+        },
+        _attach_dom_elements: function() {
+            this.$el.append(this.video).append(this.canvas);
+            this.canvas.style.display = 'none';
+        },
+        _attach_error_dom_elements: function(err) {
+            var err_dom = document.createElement('div');
+            err_dom.innerHTML = "An error has occurred, your browser does not appear " +
+                                "to support the HTML5 getUserMedia API. The " +
+                                "following error was thrown: <br/>" + err;
+            err_dom.style.width = '300px';
+            err_dom.style.textAlign = 'center';
+            this.$el.append(err_dom);
+        },
         render: function() {
             var that = this;
             that.video  = $('<video>')[0];
             that.canvas = $('<canvas>')[0];
             that.width  = that.model.get('canvas_width');
-            that.height = 480;
+            // Default value, will be overridden
+            that.height = 0;
             that.streaming = false;
 
             // Set video constraints (resolution)
-            var video_constraints  = true;
+            var video_constraints = true;
             if (that.model.get('hd')) {
-                video_constraints  = {mandatory: {minWidth: 1280, minHeight: 720}};
+                video_constraints = {
+                    mandatory: {
+                        minWidth: 1280,
+                        minHeight: 720
+                    }
+                };
             }
-
-            // Append the HTML elements
-            setTimeout(function() {
-                that.$el.append(that.video).append(that.canvas);
-                that.canvas.style.display = 'none';
-            }, 200);
 
             // Initialize the webcam
-            navigator.getMedia = (navigator.getUserMedia ||
-            navigator.webkitGetUserMedia ||
-            navigator.mozGetUserMedia ||
-            navigator.msGetUserMedia);
+            navigator.getMedia = navigator.getUserMedia       ||
+                                 navigator.webkitGetUserMedia ||
+                                 navigator.mozGetUserMedia    ||
+                                 navigator.msGetUserMedia;
 
-            navigator.getMedia({video: video_constraints, audio: false},
-                function(stream) {
-                    if (navigator.mozGetUserMedia) {
-                        that.video.mozSrcObject = stream;
-                    } else {
-                        var vendorURL = window.URL || window.webkitURL;
-                        that.video.src = vendorURL.createObjectURL(stream);
+            if (navigator.getMedia !== undefined) {
+                navigator.getMedia({video: video_constraints, audio: false},
+                    function (stream) { // Success
+                        // Add the video/hidden canvas to the DOM
+                        that._attach_dom_elements();
+
+                        // Create the stream and display it
+                        if (navigator.mozGetUserMedia) {
+                            that.video.mozSrcObject = stream;
+                        } else {
+                            var vendorURL = window.URL || window.webkitURL;
+                            that.video.src = vendorURL.createObjectURL(stream);
+                        }
+                        that.video.stream = stream;
+                        that.video.play();
+
+                        // When the video is ready resize it.
+                        that.video.addEventListener('canplay', function (_) {
+                            if (!that.streaming) {
+                                that._resize_video();
+                                that.streaming = true;
+                            }
+                        }, false);
+
+                        // Wire up event handlers
+                        that._wire_handlers();
+                    },
+                    function (err) {  // Error
+                        console.log("CameraView ERROR: " + err);
+                        that._attach_error_dom_elements(err);
                     }
-                    that.video.stream = stream;
-                    that.video.play();
-                },
-                function(err) {
-                    console.log("An error occured! " + err);
-                    that.model.set('error_occurred', true);
-                }
-            );
-
-            // Resize video
-            function resize() {
-                that.width  = that.model.get('canvas_width');
-                that.height = that.video.videoHeight / (that.video.videoWidth / that.width);
-                that.video.setAttribute('width', that.width);
-                that.video.setAttribute('height', that.height);
-                that.canvas.setAttribute('width', that.width);
-                that.canvas.setAttribute('height', that.height);
+                );
+            } else {
+                var err = 'getUserMedia === undefined';
+                console.log("CameraView ERROR: " + err);
+                that._attach_error_dom_elements(err);
             }
-
-            // Initialize the size of the canvas
-            that.video.addEventListener('canplay', function(ev){
-                if (!that.streaming) {
-                    resize();
-                    that.streaming = true;
-                }
-            }, false);
-
-            // It takes a picture and sends it to the model
-            function takepicture() {
-                that.canvas.width = that.width;
-                that.canvas.height = that.height;
-
-                // Take a screenshot from the webcam feed and put the image in the canvas
-                that.canvas.getContext('2d').drawImage(that.video, 0, 0,
-                    that.width, that.height);
-
-                // Export the canvas image to the model
-                that.model.set('imageurl', that.canvas.toDataURL('image/png'));
-                that.touch();
-            }
-
-            // Destroy the webcam
-            function destroy() {
-                if (that.video) {
-                    that.video.stream.getVideoTracks()[0].stop();
-                    delete that.video.stream;
-                    that.video.remove();
-                    delete that.video;
-                }
-                if (that.canvas) {
-                    that.canvas.remove();
-                    delete that.canvas;
-                }
-            }
-
-            // Add listeners
-            window.addEventListener('beforeunload', function(event) {
-                destroy();
-            });
-            that.model.on('change:take_snapshot', takepicture);
-            that.on("remove", destroy);
-            that.on("comm:dead", destroy);
-            that.model.on('change:canvas_width', resize);
         }
     });
 

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -10,7 +10,7 @@ from menpo.compatibility import unicode
 
 from .abstract import MenpoWidget
 from .tools import (IndexSliderWidget, IndexButtonsWidget, SlicingCommandWidget,
-                    LineOptionsWidget, MarkerOptionsWidget,
+                    LineOptionsWidget, MarkerOptionsWidget, LogoWidget,
                     NumberingOptionsWidget, LegendOptionsWidget,
                     ZoomOneScaleWidget, ZoomTwoScalesWidget, AxesOptionsWidget,
                     GridOptionsWidget, ImageOptionsWidget, CameraWidget,
@@ -5654,7 +5654,12 @@ class CameraSnapshotWidget(MenpoWidget):
             preview_windows_margin = 0
 
         # Create widgets
+        self.logo_wid = LogoWidget(style=style)
+        self.logo_wid.margin = '0.1cm'
         self.camera_wid = CameraWidget(canvas_width=canvas_width, hd=hd)
+        self.camera_wid.margin = '0.1cm'
+        self.camera_logo_box = ipywidgets.VBox(
+            children=[self.logo_wid, self.camera_wid], align='center')
         self.n_snapshots_text = ipywidgets.Latex(value='', margin=2,
                                                  visible=False)
         self.snapshot_but = ipywidgets.Button(
@@ -5668,7 +5673,7 @@ class CameraSnapshotWidget(MenpoWidget):
             icon='fa-close', description='  Close', tooltip='Close the widget',
             margin='0.1cm')
         self.zoom_widget = ZoomOneScaleWidget(
-            {'min': 0.1, 'max': 3., 'step': 0.1, 'zoom': 1.},
+            {'min': 0.1, 'max': 2.1, 'step': 0.05, 'zoom': 1.},
             continuous_update=False)
         self.zoom_widget.title.visible = False
         self.zoom_widget.zoom_text.visible = False
@@ -5688,7 +5693,7 @@ class CameraSnapshotWidget(MenpoWidget):
                                        visible=False)
 
         # Create final widget
-        children = [self.camera_wid, self.buttons_box, self.preview]
+        children = [self.camera_logo_box, self.buttons_box, self.preview]
         super(CameraSnapshotWidget, self).__init__(
             children, List, [], render_function=render_function,
             orientation='vertical', align='center')
@@ -5869,15 +5874,15 @@ class CameraSnapshotWidget(MenpoWidget):
         if style == 'minimal':
             self.snapshot_but.button_style = ''
             self.close_but.button_style = ''
-            self.zoom_widget.button_minus.button_style = 'warning'
-            self.zoom_widget.button_plus.button_style = 'warning'
+            self.zoom_widget.button_minus.button_style = ''
+            self.zoom_widget.button_plus.button_style = ''
             format_slider(self.zoom_widget.zoom_slider, slider_width='2cm',
                           slider_handle_colour=map_styles_to_hex_colours('minimal'),
                           slider_bar_colour=map_styles_to_hex_colours('minimal'),
                           slider_text_visible=False)
             self.style(box_style='', border_visible=True, border_colour='black',
                        border_style='solid', border_width=1, border_radius=0,
-                       padding='0.2cm', margin='0.5cm', font_family='',
+                       padding=0, margin=0, font_family='',
                        font_size=None, font_style='', font_weight='',
                        preview_box_style=preview_style,
                        preview_border_visible=preview_border_visible,
@@ -5898,7 +5903,7 @@ class CameraSnapshotWidget(MenpoWidget):
             self.style(box_style=style, border_visible=True,
                        border_colour=map_styles_to_hex_colours(style),
                        border_style='solid', border_width=1, border_radius=10,
-                       padding='0.2cm', margin='0.5cm', font_family='',
+                       padding=0, margin=0, font_family='',
                        font_size=None, font_style='', font_weight='',
                        preview_box_style=preview_style,
                        preview_border_visible=preview_border_visible,

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -5685,15 +5685,16 @@ class CameraSnapshotWidget(MenpoWidget):
         self.zoom_widget.button_plus.tooltip = 'Increase video resolution'
         self.zoom_widget.button_minus.tooltip = 'Decrease video resolution'
         self.zoom_widget.margin = '0.1cm'
-        self.resolution_text = ipywidgets.Text(
+        self.resolution_text = ipywidgets.Latex(
             value="{}W x {}H".format(self.camera_wid.canvas_width,
                                      self.camera_wid.canvas_height),
-            margin='0.1cm', disabled=True, width='3cm')
-        self.resolution_text.background_color = map_styles_to_hex_colours(
-            'warning', background=True)
+            margin='0.1cm')
+        self.resolution_text.font_family = 'monospace'
+        self.zoom_and_resolution_box = ipywidgets.HBox(
+            children=[self.zoom_widget, self.resolution_text], align='center')
         self.buttons_box = ipywidgets.HBox(
-            children=[self.snapshot_box, self.close_but, self.zoom_widget,
-                      self.resolution_text], align='start')
+            children=[self.snapshot_box, self.close_but,
+                      self.zoom_and_resolution_box], align='start')
         width_per_preview = int((canvas_width - preview_windows_margin * 2 *
                                  n_preview_windows) / n_preview_windows)
         preview_children = [
@@ -5896,15 +5897,19 @@ class CameraSnapshotWidget(MenpoWidget):
             self.close_but.button_style = ''
             self.zoom_widget.button_minus.button_style = ''
             self.zoom_widget.button_plus.button_style = ''
+            self.resolution_text.color = map_styles_to_hex_colours(
+                'minimal', background=False)
+            self.n_snapshots_text.color = map_styles_to_hex_colours(
+                'minimal', background=False)
             format_slider(self.zoom_widget.zoom_slider, slider_width='2cm',
                           slider_handle_colour=map_styles_to_hex_colours('minimal'),
                           slider_bar_colour=map_styles_to_hex_colours('minimal'),
                           slider_text_visible=False)
-            self.style(box_style='', border_visible=True, border_colour='black',
-                       border_style='solid', border_width=1, border_radius=0,
-                       padding=0, margin=0, font_family='',
-                       font_size=None, font_style='', font_weight='',
-                       preview_box_style=preview_style,
+            self.style(box_style='', border_visible=False,
+                       border_colour='black', border_style='solid',
+                       border_width=1, border_radius=0, padding=0, margin=0,
+                       font_family='', font_size=None, font_style='',
+                       font_weight='', preview_box_style=preview_style,
                        preview_border_visible=preview_border_visible,
                        preview_border_colour=preview_border_colour,
                        preview_border_style='solid', preview_border_width=1,
@@ -5916,6 +5921,10 @@ class CameraSnapshotWidget(MenpoWidget):
             self.close_but.button_style = 'danger'
             self.zoom_widget.button_minus.button_style = 'warning'
             self.zoom_widget.button_plus.button_style = 'warning'
+            self.resolution_text.color = map_styles_to_hex_colours(
+                'warning', background=False)
+            self.n_snapshots_text.color = map_styles_to_hex_colours(
+                'info', background=False)
             format_slider(self.zoom_widget.zoom_slider, slider_width='2cm',
                           slider_handle_colour=map_styles_to_hex_colours('warning'),
                           slider_bar_colour=map_styles_to_hex_colours('warning'),

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -5685,9 +5685,15 @@ class CameraSnapshotWidget(MenpoWidget):
         self.zoom_widget.button_plus.tooltip = 'Increase video resolution'
         self.zoom_widget.button_minus.tooltip = 'Decrease video resolution'
         self.zoom_widget.margin = '0.1cm'
+        self.resolution_text = ipywidgets.Text(
+            value="{}W x {}H".format(self.camera_wid.canvas_width,
+                                     self.camera_wid.canvas_height),
+            margin='0.1cm', disabled=True, width='3cm')
+        self.resolution_text.background_color = map_styles_to_hex_colours(
+            'warning', background=True)
         self.buttons_box = ipywidgets.HBox(
-            children=[self.snapshot_box, self.close_but, self.zoom_widget],
-            align='start')
+            children=[self.snapshot_box, self.close_but, self.zoom_widget,
+                      self.resolution_text], align='start')
         width_per_preview = int((canvas_width - preview_windows_margin * 2 *
                                  n_preview_windows) / n_preview_windows)
         preview_children = [
@@ -5743,8 +5749,17 @@ class CameraSnapshotWidget(MenpoWidget):
         # Assign zoom resolution callback
         def change_resolution(change):
             self.camera_wid.canvas_width = int(canvas_width * change['new'])
+            self.resolution_text.value = "{}W x {}H".format(
+                self.camera_wid.canvas_width, self.camera_wid.canvas_height)
         self.zoom_widget.observe(change_resolution, names='selected_values',
                                  type='change')
+
+        # Assign resolution text callback
+        def set_resolution_text(_):
+            self.resolution_text.value = "{}W x {}H".format(
+                self.camera_wid.canvas_width, self.camera_wid.canvas_height)
+        self.camera_wid.observe(set_resolution_text, names='canvas_height',
+                                type='change')
 
         # Set style
         self.predefined_style(style, preview_style)

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -5637,16 +5637,21 @@ class CameraSnapshotWidget(MenpoWidget):
     thumbnails below the stream. The video stream can be interrupted by pressing
     the "Close" button.
     """
-    # Publish javascript
-    import os.path
-    from pathlib import Path
-    menpowidgets_path =  Path(os.path.abspath(__file__)).parent
-    with open(str(menpowidgets_path / 'js' / 'webcam.js'), 'r') as f:
-        display(Javascript(data=f.read()))
+    javascript_exported = False
 
     def __init__(self, canvas_width=640, hd=True, n_preview_windows=5,
                  preview_windows_margin=3, render_function=None,
                  style='minimal', preview_style='minimal'):
+        # Publish javascript - only occurs once on construction of first
+        # webcam widget
+        if not self.javascript_exported:
+            import os.path
+            from pathlib import Path
+            menpowidgets_path =  Path(os.path.abspath(__file__)).parent
+            with open(str(menpowidgets_path / 'js' / 'webcam.js'), 'r') as f:
+                display(Javascript(data=f.read()))
+            self.javascript_exported = True
+
         # Check arguments
         if n_preview_windows < 4:
             n_preview_windows = 4

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -1,8 +1,10 @@
 import ipywidgets
+from IPython.display import display, Javascript
 from traitlets.traitlets import Int, Dict, List
 from traitlets import link
 from collections import OrderedDict
 import numpy as np
+from base64 import b64decode
 
 from menpo.compatibility import unicode
 
@@ -11,7 +13,7 @@ from .tools import (IndexSliderWidget, IndexButtonsWidget, SlicingCommandWidget,
                     LineOptionsWidget, MarkerOptionsWidget,
                     NumberingOptionsWidget, LegendOptionsWidget,
                     ZoomOneScaleWidget, ZoomTwoScalesWidget, AxesOptionsWidget,
-                    GridOptionsWidget, ImageOptionsWidget,
+                    GridOptionsWidget, ImageOptionsWidget, CameraWidget,
                     ColourSelectionWidget, HOGOptionsWidget, DSIFTOptionsWidget,
                     IGOOptionsWidget, LBPOptionsWidget, DaisyOptionsWidget)
 from .style import (map_styles_to_hex_colours, format_box, format_font,
@@ -2569,7 +2571,7 @@ class RendererOptionsWidget(MenpoWidget):
                 ``''``        No style
                 ============= ============================
         """
-        if tabs_style == 'minimal' or tabs_style=='':
+        if tabs_style == 'minimal' or tabs_style == '':
             tabs_style = ''
             tabs_border_visible = False
             tabs_border_colour = 'black'
@@ -5534,3 +5536,376 @@ class LinearModelParametersWidget(MenpoWidget):
         # trigger render function if allowed
         if allow_callback:
             self.call_render_function(old_value, self.selected_values)
+
+
+class CameraSnapshotWidget(MenpoWidget):
+    r"""
+    Creates a webcam widget for taking screenshots. The widget consists of the
+    following objects from `ipywidgets` and :ref:`api-tools-index`:
+
+    == ========================= ================== ======================
+    No Object                    Property (`self.`) Description
+    == ========================= ================== ======================
+    1  :map:`CameraWidget`       `camera_wid`       The webcam widget
+    2  `Latex`                   `n_snapshots_text` Number of snapshots
+    3  `Button`                  `snapshot_but`     Take snapshot button
+    4  `VBox`                    `snapshot_box`     Contains 3, 2
+    5  `Button`                  `close_but`        Close widget button
+    8  :map:`ZoomOneScaleWidget` `zoom_widget`      Resolution controller
+    9  `HBox`                    `buttons_box`      Contains 3, 5, 8
+    10 `Image`                   `preview_children` List of preview images
+    11 `HBox`                    `preview`          Contains all 10
+    == ========================= ================== ======================
+
+    Note that:
+
+    * The selected values are stored in the ``self.selected_values`` `trait`.
+    * To set the styling of this widget please refer to the :meth:`style` and
+      :meth:`predefined_style` methods.
+    * To update the handler callback function of the widget, please refer to the
+      :meth:`replace_render_function` method.
+
+    Parameters
+    ----------
+    canvas_width : `int`, optional
+        The initial width of the rendered canvas. Note that this doesn't actually
+        change the webcam resolution. It simply rescales the rendered image, as
+        well as the size of the returned screenshots.
+    hd : `bool`, optional
+        If ``True``, then the webcam will be set to high definition (HD), i.e.
+        720 x 1280. Otherwise the default resolution will be used.
+    n_preview_windows : `int`, optional
+        The number of preview thumbnails that will be used as a FIFO stack to
+        show the captured screenshots. It must be at least 4.
+    preview_windows_margin : `int`, optional
+        The margin between the preview thumbnails in pixels.
+    render_function : `callable` or ``None``, optional
+        The render function that is executed when a widgets' value changes.
+        It must have signature ``render_function(change)`` where ``change`` is
+        a `dict` with the following keys:
+
+        * ``type`` : The type of notification (normally ``'change'``).
+        * ``owner`` : the `HasTraits` instance
+        * ``old`` : the old value of the modified trait attribute
+        * ``new`` : the new value of the modified trait attribute
+        * ``name`` : the name of the modified trait attribute.
+
+        If ``None``, then nothing is assigned.
+    style : `str` (see below), optional
+        Sets a predefined style at the widget. Possible options are:
+
+            ============= ============================
+            Style         Description
+            ============= ============================
+            ``'minimal'`` Simple black and white style
+            ``'success'`` Green-based style
+            ``'info'``    Blue-based style
+            ``'warning'`` Yellow-based style
+            ``'danger'``  Red-based style
+            ``''``        No style
+            ============= ============================
+
+    preview_style : `str` (see below), optional
+        Sets a predefined style at the widget's preview box. Possible options
+        are:
+
+            ============= ============================
+            Style         Description
+            ============= ============================
+            ``'minimal'`` Simple black and white style
+            ``'success'`` Green-based style
+            ``'info'``    Blue-based style
+            ``'warning'`` Yellow-based style
+            ``'danger'``  Red-based style
+            ``''``        No style
+            ============= ============================
+
+    Example
+    -------
+    Let's create a webcam widget. Firstly, we need to import it:
+
+        >>> from menpowidgets.options import CameraSnapshotWidget
+
+    Create the widget with some initial options and display it:
+
+        >>> wid = CameraSnapshotWidget(canvas_width=640, hd=True,
+        >>>                            n_preview_windows=5,
+        >>>                            preview_windows_margin=1, style='info')
+        >>> wid
+
+    By pressing the "Take snapshot" button, the snapshots appear in the
+    thumbnails below the stream. The video stream can be interrupted by pressing
+    the "Close" button.
+    """
+    # Publish javascript
+    import os.path
+    from pathlib import Path
+    menpowidgets_path =  Path(os.path.abspath(__file__)).parent
+    with open(str(menpowidgets_path / 'js' / 'webcam.js'), 'r') as f:
+        display(Javascript(data=f.read()))
+
+    def __init__(self, canvas_width=640, hd=True, n_preview_windows=5,
+                 preview_windows_margin=3, render_function=None,
+                 style='minimal', preview_style='minimal'):
+        # Check arguments
+        if n_preview_windows < 4:
+            n_preview_windows = 4
+        if preview_windows_margin < 0:
+            preview_windows_margin = 0
+
+        # Create widgets
+        self.camera_wid = CameraWidget(canvas_width=canvas_width, hd=hd)
+        self.n_snapshots_text = ipywidgets.Latex(value='', margin=2,
+                                                 visible=False)
+        self.snapshot_but = ipywidgets.Button(
+            icon='fa-camera', description='  Take Snapshot',
+            tooltip='Take snapshot')
+        self.snapshot_but.style = 'primary'
+        self.snapshot_box = ipywidgets.VBox(
+            children=[self.snapshot_but, self.n_snapshots_text],
+            align='center', margin='0.1cm')
+        self.close_but = ipywidgets.Button(
+            icon='fa-close', description='  Close', tooltip='Close the widget',
+            margin='0.1cm')
+        self.zoom_widget = ZoomOneScaleWidget(
+            {'min': 0.1, 'max': 3., 'step': 0.1, 'zoom': 1.},
+            continuous_update=False)
+        self.zoom_widget.title.visible = False
+        self.zoom_widget.zoom_text.visible = False
+        self.zoom_widget.button_plus.tooltip = 'Increase video resolution'
+        self.zoom_widget.button_minus.tooltip = 'Decrease video resolution'
+        self.zoom_widget.margin = '0.1cm'
+        self.buttons_box = ipywidgets.HBox(
+            children=[self.snapshot_box, self.close_but, self.zoom_widget],
+            align='start')
+        width_per_preview = int((canvas_width - preview_windows_margin * 2 *
+                                 n_preview_windows) / n_preview_windows)
+        preview_children = [
+            ipywidgets.Image(width=width_per_preview,
+                             margin=preview_windows_margin, visible=False)
+            for k in range(n_preview_windows)]
+        self.preview = ipywidgets.HBox(children=preview_children, align='start',
+                                       visible=False)
+
+        # Create final widget
+        children = [self.camera_wid, self.buttons_box, self.preview]
+        super(CameraSnapshotWidget, self).__init__(
+            children, List, [], render_function=render_function,
+            orientation='vertical', align='center')
+
+        # Assign properties
+        self.selected_values = self.camera_wid.snapshots
+
+        # Assign take screenshot callback
+        def take_snapshot(_):
+            self.camera_wid.take_snapshot = not self.camera_wid.take_snapshot
+        self.snapshot_but.on_click(take_snapshot)
+
+        # Assign close callback
+        def close(_):
+            self.close()
+        self.close_but.on_click(close)
+
+        # Assign preview callback
+        def update_preview(_):
+            # Convert image to bytes
+            img = self.camera_wid.imageurl.encode('utf-8')
+            img = b64decode(img[len('data:image/png;base64,'):])
+            # Increase n_snapshots text
+            n_snapshots = len(self.selected_values)
+            if n_snapshots == 1:
+                self.n_snapshots_text.value = "1 snapshot"
+                self.n_snapshots_text.visible = True
+                self.preview.visible = True
+            else:
+                self.n_snapshots_text.value = "{} snapshots".format(n_snapshots)
+            # Update preview thumbnails
+            if n_snapshots <= n_preview_windows:
+                self.preview.children[n_snapshots-1].value = img
+                self.preview.children[n_snapshots-1].visible = True
+            else:
+                for k in range(n_preview_windows-1):
+                    self.preview.children[k].value = \
+                        self.preview.children[k+1].value
+                self.preview.children[n_preview_windows-1].value = img
+        self.camera_wid.observe(update_preview, names='imageurl', type='change')
+
+        # Assign zoom resolution callback
+        def change_resolution(change):
+            self.camera_wid.canvas_width = int(canvas_width * change['new'])
+        self.zoom_widget.observe(change_resolution, names='selected_values',
+                                 type='change')
+
+        # Set style
+        self.predefined_style(style, preview_style)
+
+    def style(self, box_style=None, border_visible=False, border_colour='black',
+              border_style='solid', border_width=1, border_radius=0,
+              padding='0.2cm', margin=0, preview_box_style=None,
+              preview_border_visible=True, preview_border_colour='black',
+              preview_border_style='solid', preview_border_width=1,
+              preview_border_radius=1, preview_padding=0, preview_margin=0,
+              font_family='', font_size=None, font_style='', font_weight=''):
+        r"""
+        Function that defines the styling of the widget.
+
+        Parameters
+        ----------
+        box_style : `str` or ``None`` (see below), optional
+            Possible widget style options::
+
+                'success', 'info', 'warning', 'danger', '', None
+
+        border_visible : `bool`, optional
+            Defines whether to draw the border line around the widget.
+        border_colour : `str`, optional
+            The colour of the border around the widget.
+        border_style : `str`, optional
+            The line style of the border around the widget.
+        border_width : `float`, optional
+            The line width of the border around the widget.
+        border_radius : `float`, optional
+            The radius of the border around the widget.
+        padding : `float`, optional
+            The padding around the widget.
+        margin : `float`, optional
+            The margin around the widget.
+        preview_box_style : `str` or ``None`` (see below), optional
+            Possible tab widgets style options::
+
+                'success', 'info', 'warning', 'danger', '', None
+
+        preview_border_visible : `bool`, optional
+            Defines whether to draw the border line around the preview.
+        preview_border_colour : `str`, optional
+            The color of the border around the preview.
+        preview_border_style : `str`, optional
+            The line style of the border around the preview.
+        preview_border_width : `float`, optional
+            The line width of the border around the preview.
+        preview_border_radius : `float`, optional
+            The radius of the corners of the box of the preview.
+        preview_padding : `float`, optional
+            The padding around the preview box.
+        preview_margin : `float`, optional
+            The margin around the preview box.
+        font_family : `str` (see below), optional
+            The font family to be used. Example options::
+
+                'serif', 'sans-serif', 'cursive', 'fantasy', 'monospace',
+                'helvetica'
+
+        font_size : `int`, optional
+            The font size.
+        font_style : `str` (see below), optional
+            The font style. Example options::
+
+                'normal', 'italic', 'oblique'
+
+        font_weight : See Below, optional
+            The font weight. Example options::
+
+                'ultralight', 'light', 'normal', 'regular', 'book', 'medium',
+                'roman', 'semibold', 'demibold', 'demi', 'bold', 'heavy',
+                'extra bold', 'black'
+        """
+        format_box(self, box_style, border_visible, border_colour, border_style,
+                   border_width, border_radius, padding, margin)
+        format_box(self.preview, preview_box_style, preview_border_visible,
+                   preview_border_colour, preview_border_style,
+                   preview_border_width, preview_border_radius, preview_padding,
+                   preview_margin)
+        format_font(self, font_family, font_size, font_style, font_weight)
+        format_font(self.preview, font_family, font_size, font_style,
+                    font_weight)
+
+    def predefined_style(self, style, preview_style='minimal'):
+        r"""
+        Function that sets a predefined style on the widget.
+
+        Parameters
+        ----------
+        style : `str` (see below)
+            Style options:
+
+                ============= ============================
+                Style         Description
+                ============= ============================
+                ``'minimal'`` Simple black and white style
+                ``'success'`` Green-based style
+                ``'info'``    Blue-based style
+                ``'warning'`` Yellow-based style
+                ``'danger'``  Red-based style
+                ``''``        No style
+                ============= ============================
+
+        preview_style : `str` (see below)
+            Preview box style options:
+
+                ============= ============================
+                Style         Description
+                ============= ============================
+                ``'minimal'`` Simple black and white style
+                ``'success'`` Green-based style
+                ``'info'``    Blue-based style
+                ``'warning'`` Yellow-based style
+                ``'danger'``  Red-based style
+                ``''``        No style
+                ============= ============================
+        """
+        if preview_style == 'minimal' or preview_style == '':
+            preview_style = ''
+            preview_border_visible = True
+            preview_border_colour = 'black'
+            preview_border_radius = 0
+            preview_padding = 0
+        else:
+            preview_style = preview_style
+            preview_border_visible = not style == preview_style
+            preview_border_colour = map_styles_to_hex_colours(preview_style)
+            preview_border_radius = 10
+            preview_padding = '0.3cm'
+
+        if style == 'minimal':
+            self.snapshot_but.button_style = ''
+            self.close_but.button_style = ''
+            self.zoom_widget.button_minus.button_style = 'warning'
+            self.zoom_widget.button_plus.button_style = 'warning'
+            format_slider(self.zoom_widget.zoom_slider, slider_width='2cm',
+                          slider_handle_colour=map_styles_to_hex_colours('minimal'),
+                          slider_bar_colour=map_styles_to_hex_colours('minimal'),
+                          slider_text_visible=False)
+            self.style(box_style='', border_visible=True, border_colour='black',
+                       border_style='solid', border_width=1, border_radius=0,
+                       padding='0.2cm', margin='0.5cm', font_family='',
+                       font_size=None, font_style='', font_weight='',
+                       preview_box_style=preview_style,
+                       preview_border_visible=preview_border_visible,
+                       preview_border_colour=preview_border_colour,
+                       preview_border_style='solid', preview_border_width=1,
+                       preview_border_radius=preview_border_radius,
+                       preview_padding=preview_padding, preview_margin='0.1cm')
+        elif (style == 'info' or style == 'success' or style == 'danger' or
+                      style == 'warning'):
+            self.snapshot_but.button_style = 'primary'
+            self.close_but.button_style = 'danger'
+            self.zoom_widget.button_minus.button_style = 'warning'
+            self.zoom_widget.button_plus.button_style = 'warning'
+            format_slider(self.zoom_widget.zoom_slider, slider_width='2cm',
+                          slider_handle_colour=map_styles_to_hex_colours('warning'),
+                          slider_bar_colour=map_styles_to_hex_colours('warning'),
+                          slider_text_visible=False)
+            self.style(box_style=style, border_visible=True,
+                       border_colour=map_styles_to_hex_colours(style),
+                       border_style='solid', border_width=1, border_radius=10,
+                       padding='0.2cm', margin='0.5cm', font_family='',
+                       font_size=None, font_style='', font_weight='',
+                       preview_box_style=preview_style,
+                       preview_border_visible=preview_border_visible,
+                       preview_border_colour=preview_border_colour,
+                       preview_border_style='solid', preview_border_width=1,
+                       preview_border_radius=preview_border_radius,
+                       preview_padding=preview_padding, preview_margin='0.1cm')
+        else:
+            raise ValueError('style must be minimal or info or success or '
+                             'danger or warning')

--- a/menpowidgets/tools.py
+++ b/menpowidgets/tools.py
@@ -1,9 +1,14 @@
 from collections import OrderedDict
 import ipywidgets
-from traitlets.traitlets import List, Int, Float, Dict
+from traitlets.traitlets import List, Int, Float, Dict, Bool, Unicode
 from traitlets import link
+from PIL import Image as PILImage
+from io import BytesIO
+import numpy as np
+from base64 import b64decode
 
 from menpo.compatibility import unicode
+from menpo.image import Image
 
 from .abstract import MenpoWidget
 from .style import (map_styles_to_hex_colours, convert_image_to_bytes,
@@ -5181,3 +5186,46 @@ class IGOOptionsWidget(MenpoWidget):
         format_font(self, font_family, font_size, font_style, font_weight)
         format_font(self.double_angles_checkbox, font_family, font_size,
                     font_style, font_weight)
+
+
+class CameraWidget(ipywidgets.DOMWidget):
+    r"""
+    Creates a webcam widget.
+    """
+    _view_name = Unicode('CameraView').tag(sync=True)
+    imageurl = Unicode('').tag(sync=True)
+    take_snapshot = Bool(False).tag(sync=True)
+    canvas_width = Int(640).tag(sync=True)
+    hd = Bool(True).tag(sync=True)
+    error_occurred = Bool(False).tag(sync=True)
+    snapshots = List().tag(sync=True)
+
+    def __init__(self, canvas_width=640, hd=True, *args):
+        super(CameraWidget, self).__init__(*args)
+        if self.error_occurred:
+            if hd:
+                raise ValueError("An error occurred! Either the camera is "
+                                 "not plugged or it doesn't support HD "
+                                 "resolution!")
+            else:
+                raise ValueError("An error occurred! Check that the camera is "
+                                 "plugged in!")
+        # Set tait values
+        self.canvas_width = canvas_width
+        self.hd = hd
+        # Assign callback to imageurl trait
+        self.observe(self._from_data_url, names='imageurl', type='change')
+
+    @staticmethod
+    def _from_data_url(change):
+        r"""
+        Method that converts the image in `imageurl` to `menpo.image.Image`
+        and appends it to `self.snapshots`.
+        """
+        self = change['owner']
+        data_uri = change['new']
+        data_uri = data_uri.encode('utf-8')
+        data_uri = data_uri[len('data:image/png;base64,'):]
+        im = PILImage.open(BytesIO(b64decode(data_uri)))
+        self.snapshots.append(
+            Image.init_from_channels_at_back(np.array(im)[..., :3]))

--- a/menpowidgets/tools.py
+++ b/menpowidgets/tools.py
@@ -5191,11 +5191,22 @@ class IGOOptionsWidget(MenpoWidget):
 class CameraWidget(ipywidgets.DOMWidget):
     r"""
     Creates a webcam widget.
+
+    Parameters
+    ----------
+    canvas_width : `int`, optional
+        The initial width of the rendered canvas. Note that this doesn't actually
+        change the webcam resolution. It simply rescales the rendered image, as
+        well as the size of the returned screenshots.
+    hd : `bool`, optional
+        If ``True``, then the webcam will be set to high definition (HD), i.e.
+        720 x 1280. Otherwise the default resolution will be used.
     """
     _view_name = Unicode('CameraView').tag(sync=True)
     imageurl = Unicode('').tag(sync=True)
     take_snapshot = Bool(False).tag(sync=True)
     canvas_width = Int(640).tag(sync=True)
+    canvas_height = Int().tag(sync=True)
     hd = Bool(True).tag(sync=True)
     snapshots = List().tag(sync=True)
 

--- a/menpowidgets/tools.py
+++ b/menpowidgets/tools.py
@@ -5197,19 +5197,10 @@ class CameraWidget(ipywidgets.DOMWidget):
     take_snapshot = Bool(False).tag(sync=True)
     canvas_width = Int(640).tag(sync=True)
     hd = Bool(True).tag(sync=True)
-    error_occurred = Bool(False).tag(sync=True)
     snapshots = List().tag(sync=True)
 
     def __init__(self, canvas_width=640, hd=True, *args):
         super(CameraWidget, self).__init__(*args)
-        if self.error_occurred:
-            if hd:
-                raise ValueError("An error occurred! Either the camera is "
-                                 "not plugged or it doesn't support HD "
-                                 "resolution!")
-            else:
-                raise ValueError("An error occurred! Check that the camera is "
-                                 "plugged in!")
         # Set tait values
         self.canvas_width = canvas_width
         self.hd = hd

--- a/menpowidgets/utils.py
+++ b/menpowidgets/utils.py
@@ -5,7 +5,6 @@ import matplotlib.pyplot as plt
 
 from menpo.compatibility import unicode
 from menpo.feature import glyph, sum_channels
-from menpo.visualize.viewmatplotlib import MatplotlibSubplots
 
 
 def verify_ipython_and_kernel():

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(name='menpowidgets',
                         'traitlets>=4.1,<5.0',
                         'ipython>=4.0,<5.0',
                         'jupyter>=1.0,<2.0'],
-      package_data={'menpowidgets': ['logos/*']}
+      package_data={'menpowidgets': ['logos/*', 'js/*']}
       )


### PR DESCRIPTION
This PR adds a webcam widget function (thanks to @patricksnape major contribution!!)

The widget is able to take multiple snapshots and return the captured images as a `list` of `Image` objects. It consists of the following buttons: "Take screenshot", "Close" and a resolution slider. The widget also has a panel at the bottom that visualizes the captured snapshots as thumbnails. This preview panel works as a FIFO stack and the user can determine the number of thumbnails to use.

The widget can be called as:

``` python
from menpowidgets import webcam_widget

images = webcam_widget()
```

**TODO**
- [x] Make sure that the docs build correctly. There was something going wrong with `sphinx` on my laptop.
