### PR TITLE
Animation controls

### DIFF
--- a/docs/source/menpowidgets/options/AnimationOptionsWidget.rst
+++ b/docs/source/menpowidgets/options/AnimationOptionsWidget.rst
@@ -5,6 +5,6 @@
 AnimationOptionsWidget
 ======================
 .. autoclass:: AnimationOptionsWidget
-  :members: add_render_function, remove_render_function, replace_render_function, call_render_function, set_widget_state, predefined_style, stop_animation,
+  :members: add_render_function, remove_render_function, replace_render_function, call_render_function, set_widget_state, predefined_style, stop_animation, pause_animation,
             add_traits, close, has_trait, observe, trait_names, traits, unobserve, unobserve_all
   :show-inheritance:

--- a/menpowidgets/base.py
+++ b/menpowidgets/base.py
@@ -1508,7 +1508,7 @@ def plot_graph(x_axis, y_axis, legend_entries=None, figure_size=(9, 5)):
     tmp_children.append(save_figure_wid)
     plot_wid.tab_box.children = tmp_children
     plot_wid.tab_box.set_title(0, 'Labels')
-    plot_wid.tab_box.set_title(1, 'Lines & Markers')
+    plot_wid.tab_box.set_title(1, 'Style')
     plot_wid.tab_box.set_title(2, 'Legend')
     plot_wid.tab_box.set_title(3, 'Axes')
     plot_wid.tab_box.set_title(4, 'Zoom')

--- a/menpowidgets/menpofitwidgets/base.py
+++ b/menpowidgets/menpofitwidgets/base.py
@@ -1669,7 +1669,7 @@ def plot_ced(errors, legend_entries=None, error_range=None,
     tmp_children.append(save_figure_wid)
     plot_wid.tab_box.children = tmp_children
     plot_wid.tab_box.set_title(0, 'Labels')
-    plot_wid.tab_box.set_title(1, 'Lines & Markers')
+    plot_wid.tab_box.set_title(1, 'Style')
     plot_wid.tab_box.set_title(2, 'Legend')
     plot_wid.tab_box.set_title(3, 'Axes')
     plot_wid.tab_box.set_title(4, 'Zoom')

--- a/menpowidgets/menpofitwidgets/base.py
+++ b/menpowidgets/menpofitwidgets/base.py
@@ -2087,9 +2087,8 @@ def visualize_fitting_results(fitting_results, figure_size=(7, 7),
         # If animation is activated and the user selects the save figure tab,
         # then the animation stops.
         def save_fig_tab_fun(change):
-            if (change['new'] == 3 and
-                    image_number_wid.play_stop_toggle.value):
-                image_number_wid.stop_animation()
+            if change['new'] == 3:
+                image_number_wid.pause_animation()
         options_box.observe(save_fig_tab_fun, names='selected_index',
                             type='change')
 

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -373,8 +373,7 @@ class AnimationOptionsWidget(MenpoWidget):
             self.remove_render_function()
 
             # update
-            if self.play_stop_toggle.value:
-                self.stop_animation()
+            self.stop_animation()
             if self.index_style == 'slider':
                 self.index_wid.set_widget_state(index, allow_callback=False)
             else:
@@ -4113,21 +4112,13 @@ class LinearModelParametersWidget(MenpoWidget):
         """
         self.container.box_style = style
         self.container.border = '0px'
-        if style != '':
-            self.play_button.button_style = 'success'
-            self.stop_button.button_style = 'danger'
-            self.fast_forward_button.button_style = 'info'
-            self.fast_backward_button.button_style = 'info'
-            self.loop_toggle.button_style = 'warning'
-            self.reset_button.button_style = 'danger'
-            self.plot_button.button_style = 'primary'
-        else:
-            self.play_stop_toggle.button_style = ''
-            self.fast_forward_button.button_style = ''
-            self.fast_backward_button.button_style = ''
-            self.loop_toggle.button_style = ''
-            self.reset_button.button_style = ''
-            self.plot_button.button_style = ''
+        self.play_button.button_style = 'success'
+        self.stop_button.button_style = 'danger'
+        self.fast_forward_button.button_style = 'info'
+        self.fast_backward_button.button_style = 'info'
+        self.loop_toggle.button_style = 'warning'
+        self.reset_button.button_style = 'danger'
+        self.plot_button.button_style = 'primary'
 
     def stop_animation(self):
         r"""
@@ -5315,14 +5306,9 @@ class IterativeResultOptionsWidget(MenpoWidget):
                 ============= ==================
         """
         self.container.box_style = style
-        if style != '':
-            self.plot_displacements_button.button_style = 'primary'
-            self.plot_costs_button.button_style = 'primary'
-            self.plot_errors_button.button_style = 'primary'
-        else:
-            self.plot_displacements_button.button_style = ''
-            self.plot_costs_button.button_style = ''
-            self.plot_errors_button.button_style = ''
+        self.plot_displacements_button.button_style = 'primary'
+        self.plot_costs_button.button_style = 'primary'
+        self.plot_errors_button.button_style = 'primary'
         self.index_animation.container.box_style = ''
 
     def set_widget_state(self, has_gt_shape, has_initial_shape, has_image,

--- a/menpowidgets/options.py
+++ b/menpowidgets/options.py
@@ -4157,7 +4157,7 @@ class PlotMatplotlibOptionsWidget(MenpoWidget):
             children=[self.box_1, self.lines_markers_box, self.legend_wid,
                       self.axes_wid, self.zoom_wid, self.grid_wid])
         self.tab_box.set_title(0, 'Labels')
-        self.tab_box.set_title(1, 'Lines & Markers')
+        self.tab_box.set_title(1, 'Style')
         self.tab_box.set_title(2, 'Legend')
         self.tab_box.set_title(3, 'Axes')
         self.tab_box.set_title(4, 'Zoom')
@@ -5249,7 +5249,7 @@ class CameraSnapshotWidget(MenpoWidget):
 
         # Assign preview callback
         def update_preview(_):
-            self.selected_values = self.camera_wid.snapshots.copy()
+            self.selected_values = list(self.camera_wid.snapshots)
             # Convert image to bytes
             img = self.camera_wid.imageurl.encode('utf-8')
             img = b64decode(img[len('data:image/png;base64,'):])


### PR DESCRIPTION
This PR brings back the animation controls and functionalities (remember they were intentionally disabled https://github.com/menpo/menpowidgets/pull/22 because it was not working).

In order to simplify the code, I change the animation controls. We now have all three buttons next to each other (_play_, _pause_, _stop_) instead of having a single _play/stop_ button. The difference between _pause_ and _stop_ is that the former stops the animation and remains at the current index, whereas the latter stops and resets to the first index.